### PR TITLE
Include QObject in IPluginDiagnose

### DIFF
--- a/src/iplugindiagnose.h
+++ b/src/iplugindiagnose.h
@@ -25,6 +25,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #include <vector>
 #include <functional>
+#include <QObject>
 #include <QString>
 #pragma warning(push)
 #pragma warning(disable: 4100)


### PR DESCRIPTION
Parts of this header rely on QObject having been imported, but until now it's relied on other files including it.

(e.g. when this is included in `plugincontainer.h`, that file first includes `previewgenerator.h`, which in turn includes `QWidget`, which includes some things which eventually include Qt's internal QObject header. Therefore if `previewgenerator.h` got moved later in the list of includes, suddenly Mod Organizer wouldn't compile.)