### PR TITLE
Migrate to python 3

### DIFF
--- a/src/idownloadmanager.h
+++ b/src/idownloadmanager.h
@@ -42,7 +42,7 @@ public:
    */
   virtual QString downloadPath(int id) = 0;
 
-signals:
+Q_SIGNALS:
 
   /**
    * @brief emitted when the download has finished completely (including retrieval of meta information)

--- a/src/imodrepositorybridge.h
+++ b/src/imodrepositorybridge.h
@@ -62,7 +62,7 @@ private:
 
   Q_DISABLE_COPY(IModRepositoryBridge)
 
-signals:
+Q_SIGNALS:
 
   /**
    * @brief sent when the description for a mod is reported by the repository

--- a/src/iplugintool.h
+++ b/src/iplugintool.h
@@ -57,7 +57,7 @@ public:
    */
   virtual void setParentWidget(QWidget *widget) { m_ParentWidget = widget; }
 
-public slots:
+public Q_SLOTS:
 
   /**
    * @brief called when the user clicks to start the tool.


### PR DESCRIPTION
These changes are needed because of conflicting keyword naming between Qt and Python 3.