### PR TITLE
Moved formatSystemMessage() from main repo

### DIFF
--- a/src/utility.h
+++ b/src/utility.h
@@ -388,6 +388,9 @@ bool isOneOf(const T &val, const std::initializer_list<T> &list) {
   return std::find(list.begin(), list.end(), val) != list.end();
 }
 
+QDLLEXPORT std::wstring formatSystemMessage(DWORD id);
+QDLLEXPORT QString formatSystemMessageQ(DWORD id);
+
 } // namespace MOBase
 
 #endif // UTILITY_H


### PR DESCRIPTION
I renamed to original to `formatSystemMessageQ()` and added a new `formatSystemMessage()` that returns a `std::wstring.` I also fixed `LogShellFailure()` not logging stuff correctly because it was using variadic arguments.

This is dependent on PR https://github.com/ModOrganizer2/modorganizer/pull/781.