### PR TITLE
Crash when switching instances

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -253,7 +253,10 @@ void Logger::setFile(const File& f)
     try
     {
       m_file = createFileSink(f);
-      ds->add_sink(m_file);
+
+      if (m_file) {
+        ds->add_sink(m_file);
+      }
     }
     catch(spdlog::spdlog_ex& e)
     {


### PR DESCRIPTION
Don't add empty sinks, happens when switching instances when the file sink is reset