### PR TITLE
Update WriteRegistryValue to use TaskDialog window and remember choices

### DIFF
--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -47,19 +47,30 @@ bool WriteRegistryValue(LPCWSTR appName, LPCWSTR keyName, LPCWSTR value, LPCWSTR
               QObject::tr("Clear the read-only flag"),
               QMessageBox::Yes})
             .button({
+              QObject::tr("Allow the write once"),
+              QObject::tr("The file will be set to read-only again."),
+              QMessageBox::Ignore})
+            .button({
               QObject::tr("Skip this file"),
               QMessageBox::No})
             .remember("clearReadOnly",fileInfo.fileName())
             .exec();
 
-          if (result == QMessageBox::Yes) {
+          // clear the read-only flag if requested
+          if (result & (QMessageBox::Yes |QMessageBox::Ignore)) {
             attrs &= ~(FILE_ATTRIBUTE_READONLY);
             if (::SetFileAttributes(fileName, attrs)) {
               if (::WritePrivateProfileString(appName, keyName, value, fileName)) {
                 success = true;
               }
             }
-          } 
+          }
+
+          // set the read-only flag if requested
+          if (result == QMessageBox::Ignore) {
+            attrs |= FILE_ATTRIBUTE_READONLY;
+            ::SetFileAttributes(fileName, attrs);
+          }
         }
       } break;
     }

--- a/src/registry.cpp
+++ b/src/registry.cpp
@@ -34,22 +34,22 @@ bool WriteRegistryValue(LPCWSTR appName, LPCWSTR keyName, LPCWSTR value, LPCWSTR
       {
         DWORD attrs = ::GetFileAttributes(fileName);
         if ((attrs != INVALID_FILE_ATTRIBUTES) && (attrs & FILE_ATTRIBUTE_READONLY)) {
+          QFileInfo fileInfo(QString("%1").arg(fileName));
+
           QMessageBox::StandardButton result =
             MOBase::TaskDialog(
               qApp->activeModalWidget(),
-              qApp->tr("INI file is read-only"))
-            .main(qApp->tr("INI file is read-only"))
-            .content(qApp->tr("Mod Organizer is attempting to write to \"%1\" which is currently set to read-only. "
-              "Clear the read-only flag to allow the write?").arg(fileName))
-            .icon(QMessageBox::Question)
+              QObject::tr("INI file is read-only"))
+            .main(QObject::tr("INI file is read-only"))
+            .content(QObject::tr("Mod Organizer is attempting to write to \"%1\" which is currently set to read-only.").arg(fileInfo.fileName()))
+            .icon(QMessageBox::Warning)
             .button({
-              qApp->tr("Clear the read-only flag"),
+              QObject::tr("Clear the read-only flag"),
               QMessageBox::Yes})
             .button({
-              qApp->tr("Do nothing"),
-              qApp->tr("The write operation may fail."),
-              QMessageBox::Cancel})
-            .remember("clearReadOnly", QString("%1").arg(fileName))
+              QObject::tr("Skip this file"),
+              QMessageBox::No})
+            .remember("clearReadOnly",fileInfo.fileName())
             .exec();
 
           if (result == QMessageBox::Yes) {


### PR DESCRIPTION
Some users value the ability to keep INI files as read-only and do not
want to be constantly nagged to clear the read-only status.  This allows
them to silence the nags.

Also, new fancy dialog box.