### PR TITLE
Provide details of error source

### DIFF
--- a/src/safewritefile.cpp
+++ b/src/safewritefile.cpp
@@ -32,11 +32,11 @@ SafeWriteFile::SafeWriteFile(const QString &fileName)
 {
   if (!m_TempFile.open()) {
     log::error(
-      "attempt to create file at {} for {} failed (error {}: {})"
-      , QDir::tempPath()
+      "failed to open temporary file '{}', error {} ('{}'), temp path is '{}'"
       , m_FileName
       , m_TempFile.error()
-      , m_TempFile.errorString());
+      , m_TempFile.errorString()
+      , QDir::tempPath());
     
     QString errorMsg;
     switch (m_TempFile.error()) {
@@ -53,6 +53,7 @@ SafeWriteFile::SafeWriteFile(const QString &fileName)
           .arg(QDir::tempPath());
         break;
       case QFileDevice::FileError::NoError:  // fall-through
+      case QFileDevice::FileError::ReadError:
       case QFileDevice::FileError::WriteError:
       case QFileDevice::FileError::FatalError:
       case QFileDevice::FileError::OpenError:

--- a/src/safewritefile.cpp
+++ b/src/safewritefile.cpp
@@ -30,7 +30,7 @@ SafeWriteFile::SafeWriteFile(const QString &fileName)
 : m_FileName(fileName)
 {
   if (!m_TempFile.open()) {
-    throw MyException(QObject::tr("failed to open temporary file"));
+    throw MyException(QObject::tr(m_TempFile.errorString().toLocal8Bit().data()));
   }
 }
 


### PR DESCRIPTION
In case of an error while opening a temporary file the specific error
message instead of a generic one will be used.