### PR TITLE
Filter widget and more

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -68,6 +68,7 @@ SET(uibase_SRCS
     eventfilter.cpp
 	errorcodes.cpp
 	linklabel.cpp
+	widgetutility.cpp
   )
 
 SET(uibase_HDRS
@@ -128,6 +129,7 @@ SET(uibase_HDRS
     filterwidget.h
 	errorcodes.h
 	linklabel.h
+	widgetutility.h
   )
 
 SET(UIS
@@ -183,6 +185,7 @@ set(widgets
 	expanderwidget
     filterwidget
 	linklabel
+	widgetutility
 )
 
 set(src_filters interfaces tutorials widgets

--- a/src/filterwidget.cpp
+++ b/src/filterwidget.cpp
@@ -326,9 +326,17 @@ void FilterWidget::setListBorder(bool active)
   }
 
   if (auto* s=m_list->style()) {
+    // changing properties doesn't repolish automatically
     s->unpolish(m_list);
     s->polish(m_list);
   }
+
+  // the qss will probably change the border, which requires sending a manual
+  // StyleChange because the box model has changed
+  QEvent event(QEvent::StyleChange);
+  QApplication::sendEvent(m_list, &event);
+  m_list->update();
+  m_list->updateGeometry();
 }
 
 } // namespace

--- a/src/filterwidget.cpp
+++ b/src/filterwidget.cpp
@@ -272,21 +272,24 @@ void FilterWidget::onTextChanged()
   m_clear->setVisible(!m_edit->text().isEmpty());
 
   const auto text = m_edit->text();
-
-  if (text != m_text) {
-    const QString old = m_text;
-
-    emit aboutToChange(old, text);
-
-    m_text = text;
-    compile();
-
-    if (m_proxy) {
-      m_proxy->invalidateFilter();
-    }
-
-    emit changed(old, text);
+  if (text == m_text) {
+    return;
   }
+
+  const QString old = m_text;
+
+  emit aboutToChange(old, text);
+
+  m_text = text;
+  compile();
+
+  if (m_proxy) {
+    m_proxy->invalidateFilter();
+  }
+
+  setListBorder(!m_text.isEmpty());
+
+  emit changed(old, text);
 }
 
 void FilterWidget::onResized()
@@ -308,6 +311,24 @@ void FilterWidget::repositionClearButton()
   const auto y = (r.bottom() + 1 - sz.height()) / 2;
 
   m_clear->move(x, y);
+}
+
+void FilterWidget::setListBorder(bool active)
+{
+  if (!m_list) {
+    return;
+  }
+
+  if (active) {
+    m_list->setProperty("filtered", true);
+  } else {
+    m_list->setProperty("filtered", false);
+  }
+
+  if (auto* s=m_list->style()) {
+    s->unpolish(m_list);
+    s->polish(m_list);
+  }
 }
 
 } // namespace

--- a/src/filterwidget.h
+++ b/src/filterwidget.h
@@ -7,6 +7,7 @@
 #include <QList>
 #include <QAbstractItemView>
 #include <QSortFilterProxyModel>
+#include <QRegularExpression>
 #include "dllimport.h"
 
 namespace MOBase {
@@ -39,7 +40,7 @@ private:
 
   bool columnMatches(
     int sourceRow, const QModelIndex& sourceParent,
-    int c, const QString& what) const;
+    int c, const QRegularExpression& what) const;
 };
 
 
@@ -48,9 +49,19 @@ class QDLLEXPORT FilterWidget : public QObject
   Q_OBJECT;
 
 public:
-  using predFun = std::function<bool (const QString& what)>;
+  struct Options
+  {
+    bool useRegex = false;
+    bool regexCaseSensitive = false;
+    bool regexExtended = false;
+  };
+
+  using predFun = std::function<bool (const QRegularExpression& what)>;
 
   FilterWidget();
+
+  static void setOptions(const Options& o);
+  static Options options();
 
   void setEdit(QLineEdit* edit);
   void setList(QAbstractItemView* list);
@@ -74,13 +85,16 @@ signals:
   void changed(const QString& oldFilter, const QString& newFilter);
 
 private:
+  using Compiled = QList<QList<QRegularExpression>>;
+
   QLineEdit* m_edit;
   QAbstractItemView* m_list;
   FilterWidgetProxyModel* m_proxy;
   EventFilter* m_eventFilter;
   QToolButton* m_clear;
   QString m_text;
-  QList<QList<QString>> m_compiled;
+  Compiled m_compiled;
+  bool m_valid;
 
   void unhook();
   void createClear();
@@ -89,8 +103,10 @@ private:
 
   void onTextChanged();
   void onResized();
-  void setListBorder(bool active);
+  void onContextMenu(QObject*, QContextMenuEvent* e);
 
+  void set(const QString& text);
+  void update();
   void compile();
 };
 

--- a/src/filterwidget.h
+++ b/src/filterwidget.h
@@ -23,20 +23,12 @@ public:
   FilterWidgetProxyModel(FilterWidget& fw, QWidget* parent=nullptr);
   using QSortFilterProxyModel::invalidateFilter;
 
-  void setUseSourceSort(bool b);
-  bool useSourceSort() const;
-
-  void setFilterColumn(int i);
-  int filterColumn() const;
-
 protected:
   bool filterAcceptsRow(int row, const QModelIndex& parent) const override;
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
 
 private:
   FilterWidget& m_filter;
-  bool m_useSourceSort;
-  int m_filterColumn;
 
   bool columnMatches(
     int sourceRow, const QModelIndex& sourceParent,
@@ -95,6 +87,8 @@ private:
   QString m_text;
   Compiled m_compiled;
   bool m_valid;
+  bool m_useSourceSort;
+  int m_filterColumn;
 
   void unhook();
   void createClear();

--- a/src/filterwidget.h
+++ b/src/filterwidget.h
@@ -89,6 +89,7 @@ private:
 
   void onTextChanged();
   void onResized();
+  void setListBorder(bool active);
 
   void compile();
 };

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -890,4 +890,24 @@ QDLLEXPORT void localizedByteSizeTests()
 #undef CHECK_EQ
 }
 
+
+TimeThis::TimeThis(QString what)
+  : m_what(std::move(what)), m_start(Clock::now())
+{
+}
+
+TimeThis::~TimeThis()
+{
+  using namespace std::chrono;
+
+  const auto end = Clock::now();
+  const auto d = duration_cast<milliseconds>(end - m_start).count();
+
+  if (m_what.isEmpty()) {
+    log::debug("{} ms", d);
+  } else {
+    log::debug("{} {} ms", m_what, d);
+  }
+}
+
 } // namespace MOBase

--- a/src/version.rc
+++ b/src/version.rc
@@ -4,7 +4,7 @@
 // Otherwise, if letters are used in VER_FILEVERSION_STR, uses the full MOBase::VersionInfo parser
 // Otherwise, uses the numbers from VER_FILEVERSION and sets the release type as pre-alpha
 #define VER_FILEVERSION     2,3,0
-#define VER_FILEVERSION_STR "2.3.0alpha5\0"
+#define VER_FILEVERSION_STR "2.3.0alpha6\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION

--- a/src/widgetutility.cpp
+++ b/src/widgetutility.cpp
@@ -1,0 +1,53 @@
+#include "widgetutility.h"
+#include "eventfilter.h"
+#include "log.h"
+#include <QHeaderView>
+#include <QCheckBox>
+#include <QWidgetAction>
+
+namespace MOBase
+{
+
+void onHeaderContextMenu(QTreeView* view, const QPoint& pos)
+{
+  auto* header = view->header();
+
+  QMenu menu;
+
+  // display a list of all headers as checkboxes
+  QAbstractItemModel* model = header->model();
+
+  for (int i = 1; i < model->columnCount(); ++i) {
+    const QString columnName =
+      model->headerData(i, Qt::Horizontal).toString();
+
+    auto* checkBox = new QCheckBox(&menu);
+    checkBox->setText(columnName);
+    checkBox->setChecked(!header->isSectionHidden(i));
+
+    auto* checkableAction = new QWidgetAction(&menu);
+    checkableAction->setDefaultWidget(checkBox);
+
+    QObject::connect(checkBox, &QCheckBox::clicked, [=]{
+      header->setSectionHidden(i, !checkBox->isChecked());
+    });
+
+    menu.addAction(checkableAction);
+  }
+
+  menu.exec(header->viewport()->mapToGlobal(pos));
+}
+
+void setCustomizableColumns(QTreeView* view)
+{
+  auto* header = view->header();
+
+  header->setSectionsMovable(true);
+  header->setContextMenuPolicy(Qt::CustomContextMenu);
+
+  QObject::connect(
+    header, &QWidget::customContextMenuRequested,
+    view, [view](auto&& pos){ onHeaderContextMenu(view, pos); });
+}
+
+} // namespace

--- a/src/widgetutility.h
+++ b/src/widgetutility.h
@@ -1,0 +1,14 @@
+#ifndef UIBASE_WIDGETUTILITY_INCLUDED
+#define UIBASE_WIDGETUTILITY_INCLUDED
+
+#include "dllimport.h"
+#include <QAbstractItemView>
+
+namespace MOBase
+{
+
+QDLLEXPORT void setCustomizableColumns(QTreeView* view);
+
+} // namespace
+
+#endif // UIBASE_WIDGETUTILITY_INCLUDED


### PR DESCRIPTION
- Filtered lists now set the `filtered` property instead of hardcoding red borders
- Moved flags back into `FilterWidget` instead of the model so they can be set before the list
- Regex for filters
- `TimeThis` from modorganizer
- `forEachLineInFile()` from game_gamebryo
- `setCustomizableColumns()`