### PR TITLE
Filterwidget updates

### DIFF
--- a/src/filterwidget.cpp
+++ b/src/filterwidget.cpp
@@ -128,6 +128,13 @@ void FilterWidget::clear()
   m_edit->clear();
 }
 
+void FilterWidget::scrollToSelection()
+{
+  if (options().scrollToSelection && m_list && m_list->selectionModel()->hasSelection()) {
+    m_list->scrollTo(m_list->selectionModel()->selectedIndexes()[0]);
+  }
+}
+
 bool FilterWidget::empty() const
 {
   return m_text.isEmpty();
@@ -329,6 +336,7 @@ void FilterWidget::set(const QString& text)
 
   if (m_list) {
     setStyleProperty(m_list, "filtered", !m_text.isEmpty());
+    scrollToSelection();
   }
 
   emit changed(old, text);
@@ -407,11 +415,22 @@ void FilterWidget::onContextMenu(QObject*, QContextMenuEvent* e)
     update();
   });
 
+  auto* sts = new QAction(tr("Keep selection in view"), m_edit);
+  sts->setStatusTip(tr("Scroll to keep the current selection in view after filtering"));
+  sts->setCheckable(true);
+  sts->setChecked(s_options.scrollToSelection);
+
+  connect(sts, &QAction::triggered, [&] {
+    s_options.scrollToSelection = sts->isChecked();
+    update();
+    });
+
 
   m->insertSeparator(m->actions().first());
   m->insertAction(m->actions().first(), x);
   m->insertAction(m->actions().first(), cs);
   m->insertAction(m->actions().first(), regex);
+  m->insertAction(m->actions().first(), sts);
   m->insertAction(m->actions().first(), title);
 
   m->exec(e->globalPos());

--- a/src/filterwidget.cpp
+++ b/src/filterwidget.cpp
@@ -118,9 +118,14 @@ void FilterWidget::setList(QAbstractItemView* list)
 {
   m_list = list;
 
-  m_proxy = new FilterWidgetProxyModel(*this);
-  m_proxy->setSourceModel(m_list->model());
-  m_list->setModel(m_proxy);
+  if (list == nullptr) {
+    m_proxy = nullptr;
+  }
+  else {
+    m_proxy = new FilterWidgetProxyModel(*this);
+    m_proxy->setSourceModel(m_list->model());
+    m_list->setModel(m_proxy);
+  }
 }
 
 void FilterWidget::clear()

--- a/src/filterwidget.h
+++ b/src/filterwidget.h
@@ -46,6 +46,7 @@ public:
     bool useRegex = false;
     bool regexCaseSensitive = false;
     bool regexExtended = false;
+    bool scrollToSelection = false;
   };
 
   using predFun = std::function<bool (const QRegularExpression& what)>;
@@ -58,6 +59,7 @@ public:
   void setEdit(QLineEdit* edit);
   void setList(QAbstractItemView* list);
   void clear();
+  void scrollToSelection();
   bool empty() const;
 
   void setUseSourceSort(bool b);

--- a/src/filterwidget.h
+++ b/src/filterwidget.h
@@ -62,6 +62,9 @@ public:
   void scrollToSelection();
   bool empty() const;
 
+  void setUpdateDelay(bool b);
+  bool hasUpdateDelay() const;
+
   void setUseSourceSort(bool b);
   bool useSourceSort() const;
 
@@ -88,6 +91,8 @@ private:
   QToolButton* m_clear;
   QString m_text;
   Compiled m_compiled;
+  QTimer* m_timer;
+  bool m_useDelay;
   bool m_valid;
   bool m_useSourceSort;
   int m_filterColumn;
@@ -101,7 +106,7 @@ private:
   void onResized();
   void onContextMenu(QObject*, QContextMenuEvent* e);
 
-  void set(const QString& text);
+  void set();
   void update();
   void compile();
 };


### PR DESCRIPTION
- Added option to keep selection in view while filtering
- Added optional delay before filtering after text changed to stack multiple changes into a single filter pass.
- Avoid crash when nullptr is passed to setList()

Requires merging matching PR in modorganizer