### PR TITLE
MO_ASSERT

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -130,6 +130,7 @@ SET(uibase_HDRS
 	errorcodes.h
 	linklabel.h
 	widgetutility.h
+	moassert.h
   )
 
 SET(UIS

--- a/src/moassert.h
+++ b/src/moassert.h
@@ -7,19 +7,22 @@ namespace MOBase
 {
 
 template <class T>
-inline void mo_assert(
+inline void MOAssert(
   T&& t, const char* exp, const char* file, int line, const char* func)
 {
   if (!t)
   {
     log::error("assertion failed: {}:{} {}: '{}'", file, line, func, exp);
-    DebugBreak();
+
+    if (IsDebuggerPresent()) {
+      DebugBreak();
+    }
   }
 }
 
 } // namespace
 
 
-#define MO_ASSERT(v) mo_assert(v, #v, __FILE__, __LINE__, __FUNCSIG__);
+#define MO_ASSERT(v) MOAssert(v, #v, __FILE__, __LINE__, __FUNCSIG__)
 
 #endif // UIBASE_MOASSERT_INCLUDED

--- a/src/moassert.h
+++ b/src/moassert.h
@@ -1,0 +1,25 @@
+#ifndef UIBASE_MOASSERT_INCLUDED
+#define UIBASE_MOASSERT_INCLUDED
+
+#include "log.h"
+
+namespace MOBase
+{
+
+template <class T>
+inline void mo_assert(
+  T&& t, const char* exp, const char* file, int line, const char* func)
+{
+  if (!t)
+  {
+    log::error("assertion failed: {}:{} {}: '{}'", file, line, func, exp);
+    DebugBreak();
+  }
+}
+
+} // namespace
+
+
+#define MO_ASSERT(v) mo_assert(v, #v, __FILE__, __LINE__, __FUNCSIG__);
+
+#endif // UIBASE_MOASSERT_INCLUDED


### PR DESCRIPTION
Added an `MO_ASSERT` macro in `moassert.h`. It will always log the failed assertion and will break into the debugger when present.