### PR TITLE
Make IFileTree read-only operations thread-safe

### DIFF
--- a/src/ifiletree.cpp
+++ b/src/ifiletree.cpp
@@ -741,19 +741,11 @@ namespace MOBase {
    * @return the vector of entries.
    */
   std::vector<std::shared_ptr<FileTreeEntry>>& IFileTree::entries() {
-    // Use this "weird" order for atomic:
-    if (m_Populated) {
-      return m_Entries;
-    }
-    populate();
+    std::call_once(m_OnceFlag, [this]() { populate(); });
     return m_Entries;
   }
   const std::vector<std::shared_ptr<FileTreeEntry>>& IFileTree::entries() const {
-    // Use this "weird" order for atomic:
-    if (m_Populated) {
-      return m_Entries;
-    }
-    populate();
+    std::call_once(m_OnceFlag, [this]() { populate(); });
     return m_Entries;
   }
 
@@ -761,11 +753,6 @@ namespace MOBase {
    * @brief Populate the internal vectors and update the flag.
    */
   void IFileTree::populate() const {
-    std::unique_lock lock(m_Mutex);
-
-    // Check that the tree was not being populated while waiting on the lock:
-    if (m_Populated) return;
-
     // Populate:
     if (!doPopulate(astree(), m_Entries)) {
       std::sort(std::begin(m_Entries), std::end(m_Entries), FileEntryComparator{});

--- a/src/ifiletree.h
+++ b/src/ifiletree.h
@@ -1037,8 +1037,8 @@ namespace MOBase {
     std::shared_ptr<IFileTree> createTree(QStringList::const_iterator begin, QStringList::const_iterator end);
     
     // Indicate if this tree has been populated:
-    mutable std::mutex m_Mutex;
-    mutable std::atomic<bool> m_Populated = false;
+    mutable std::atomic<bool> m_Populated{ false };
+    mutable std::once_flag m_OnceFlag;
     mutable std::vector<std::shared_ptr<FileTreeEntry>> m_Entries;
 
     /**

--- a/src/ifiletree.h
+++ b/src/ifiletree.h
@@ -334,6 +334,9 @@ namespace MOBase {
    * classes only have to implement methods to populate the tree and to create child tree
    * object.
    *
+   * Read-only operations on the tree are thread-safe, even when the tree has not been populated
+   * yet.
+   *
    * In order to prevent wrong usage of the tree, implementing classes may throw 
    * UnsupportedOperationException if an operation is not supported. By default, all operations
    * are supported, but some may not make sense in many situations.

--- a/src/ifiletree.h
+++ b/src/ifiletree.h
@@ -21,9 +21,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef IFILETREE_H
 #define IFILETREE_H
 
+#include <atomic>
 #include <stdexcept>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 #include <QFlags>
@@ -1035,7 +1037,8 @@ namespace MOBase {
     std::shared_ptr<IFileTree> createTree(QStringList::const_iterator begin, QStringList::const_iterator end);
     
     // Indicate if this tree has been populated:
-    mutable bool m_Populated = false;
+    mutable std::mutex m_Mutex;
+    mutable std::atomic<bool> m_Populated = false;
     mutable std::vector<std::shared_ptr<FileTreeEntry>> m_Entries;
 
     /**


### PR DESCRIPTION
Small modifications to `IFileTree` to have thread-safe read operations:
- Within read operations, the only thing that can be modified is the `m_Entries` vector when being populated, so it's the only section of the code that need lock-mechanisms.
- I did not notice even the smallest impact on performance, I think that `std::call_once` is pretty well implemented.
