### PR TITLE
Minor stuffs

### DIFF
--- a/src/ifiletree.cpp
+++ b/src/ifiletree.cpp
@@ -13,6 +13,14 @@ namespace MOBase {
     return (isDir() || idx == -1) ? "" : m_Name.mid(idx + 1);
   }
 
+  bool FileTreeEntry::hasSuffix(QString suffix) const {
+    return this->suffix().compare(suffix, FileNameComparator::CaseSensitivity) == 0;
+  }
+
+  bool FileTreeEntry::hasSuffix(QStringList suffixes) const {
+    return suffixes.contains(suffix(), FileNameComparator::CaseSensitivity);
+  }
+
   QString FileTreeEntry::pathFrom(std::shared_ptr<const IFileTree> tree, QString sep) const {
 
     // We will construct the path from right to left:

--- a/src/ifiletree.h
+++ b/src/ifiletree.h
@@ -221,6 +221,24 @@ namespace MOBase {
     QString suffix() const;
 
     /**
+     * @brief Check if this entry has the given suffix.
+     *
+     * @param suffix Suffix of to check.
+     *
+     * @return true if this entry is a file and has the given suffix.
+     */
+    bool hasSuffix(QString suffix) const;
+
+    /**
+     * @brief Check if this entry has one of the given suffixes.
+     *
+     * @param suffixes Suffixes of to check.
+     *
+     * @return true if this entry is a file and has the given suffix.
+     */
+    bool hasSuffix(QStringList suffixes) const;
+
+    /**
      * @brief Retrieve the path from this entry up to the root of the tree.
      *
      * This method propagate up the tree so is not constant complexity as

--- a/src/ifiletree.h
+++ b/src/ifiletree.h
@@ -85,7 +85,7 @@ namespace MOBase {
      * @return -1, 0 or 1 if the first one is less, equal or greater than the second one.
      */
     static int compare(QString const& lhs, QString const& rhs) {
-      return lhs.compare(rhs, Qt::CaseInsensitive);
+      return lhs.compare(rhs, CaseSensitivity);
     }
 
     /**


### PR DESCRIPTION
- Minor fix to `FileNameComparator` (use the static `CaseSensitivity` instead of `Qt::CaseInsensitive`).
- Add `hasSuffix` methods which can be useful (perform case-insensitive comparison for us). Recompute the suffix each time though.