### PR TITLE
Minor changes and cleaning for ModDataContent

### DIFF
--- a/src/utility.h
+++ b/src/utility.h
@@ -357,27 +357,6 @@ public:
   IncompatibilityException(const QString &text) : MyException(text) {}
 };
 
-
-/**
- * @brief convenience template to create a vector in a single call using vararg semantic
- *
- * @param count number of elements
- * @param  ... parameters (should be exactly "count" elements)
- * @return the constructed vector
- **/
-template <typename T>
-std::vector<T> MakeVector(int count, ...)
-{
-  std::vector<T> result;
-  va_list argList;
-  va_start(argList, count);
-  for (int i = 0; i < count; ++i) {
-    result.push_back(va_arg(argList, int));
-  }
-  va_end(argList);
-  return result;
-}
-
 template <typename T>
 QList<T> ConvertList(const QVariantList &variants)
 {

--- a/src/widgetutility.cpp
+++ b/src/widgetutility.cpp
@@ -25,6 +25,9 @@ void onHeaderContextMenu(QTreeView* view, const QPoint& pos)
     checkBox->setText(columnName);
     checkBox->setChecked(!header->isSectionHidden(i));
 
+    auto display = model->headerData(i, Qt::Horizontal, EnabledColumnRole);
+    checkBox->setEnabled(!display.isValid() || display.toBool());
+
     auto* checkableAction = new QWidgetAction(&menu);
     checkableAction->setDefaultWidget(checkBox);
 

--- a/src/widgetutility.cpp
+++ b/src/widgetutility.cpp
@@ -25,8 +25,13 @@ void onHeaderContextMenu(QTreeView* view, const QPoint& pos)
     checkBox->setText(columnName);
     checkBox->setChecked(!header->isSectionHidden(i));
 
+    // Enable the checkbox if 1) the section is visible, or 2) the
+    // EnabledColumnRole is not found, or 3) the value for the role is true.
     auto display = model->headerData(i, Qt::Horizontal, EnabledColumnRole);
-    checkBox->setEnabled(!display.isValid() || display.toBool());
+    checkBox->setEnabled(
+      !header->isSectionHidden(i)
+      || !display.isValid()
+      || display.toBool());
 
     auto* checkableAction = new QWidgetAction(&menu);
     checkableAction->setDefaultWidget(checkBox);

--- a/src/widgetutility.h
+++ b/src/widgetutility.h
@@ -7,6 +7,11 @@
 namespace MOBase
 {
 
+  /**
+   * Custom user-role that can be used in conjunction with `setCustomizableColumns`. If 
+   * a column has a value for this role, and the value is false, the checkbox corresponding
+   * to the column will be disabled, otherwise the checkbox is enabled.
+   */
   constexpr auto EnabledColumnRole = Qt::UserRole + 1;
 
   QDLLEXPORT void setCustomizableColumns(QTreeView* view);

--- a/src/widgetutility.h
+++ b/src/widgetutility.h
@@ -7,7 +7,9 @@
 namespace MOBase
 {
 
-QDLLEXPORT void setCustomizableColumns(QTreeView* view);
+  constexpr auto EnabledColumnRole = Qt::UserRole + 1;
+
+  QDLLEXPORT void setCustomizableColumns(QTreeView* view);
 
 } // namespace
 


### PR DESCRIPTION
- Make it possible to dynamically hide column checkbox in `setCustomizableColumns` using a user-defined Qt role.
- Removed old `MakeVector`.
