### PR TITLE
Installation manager improvements

### DIFF
--- a/src/ifiletree.cpp
+++ b/src/ifiletree.cpp
@@ -767,11 +767,14 @@ namespace MOBase {
    * @brief Populate the internal vectors and update the flag.
    */
   void IFileTree::populate() const {
-    // Populate:
-    if (!doPopulate(astree(), m_Entries)) {
-      std::sort(std::begin(m_Entries), std::end(m_Entries), FileEntryComparator{});
+    // Need to check m_Populated again here since the tree can be populated without
+    // a call to entries() (e.g., on copy/orphanTree):
+    if (!m_Populated) {
+      if (!doPopulate(astree(), m_Entries)) {
+        std::sort(std::begin(m_Entries), std::end(m_Entries), FileEntryComparator{});
+      }
+      m_Populated = true;
     }
-    m_Populated = true;
   }
 
 }

--- a/src/ifiletree.cpp
+++ b/src/ifiletree.cpp
@@ -152,11 +152,12 @@ namespace MOBase {
   /**
    *
    */
-  std::shared_ptr<FileTreeEntry> IFileTree::addFile(QString path) {
+  std::shared_ptr<FileTreeEntry> IFileTree::addFile(QString path, bool replaceIfExists) {
     QStringList parts = splitPath(path);
 
     // Check if the file already exists:
-    if (fetchEntry(parts, IFileTree::FILE_OR_DIRECTORY) != nullptr) {
+    auto existingEntry = fetchEntry(parts, IFileTree::FILE_OR_DIRECTORY);
+    if (!replaceIfExists && existingEntry != nullptr) {
       return nullptr;
     }
 
@@ -184,6 +185,11 @@ namespace MOBase {
     // If makeFile returns a null pointer, it means we cannot create file:
     if (entry == nullptr) {
       return nullptr;
+    }
+
+    // Remove the existing files if there was one:
+    if (existingEntry) {
+      existingEntry->detach();
     }
 
     // Insert in the tree:

--- a/src/ifiletree.cpp
+++ b/src/ifiletree.cpp
@@ -179,7 +179,7 @@ namespace MOBase {
       tree = this;
     }
 
-    std::shared_ptr<FileTreeEntry> entry = tree->makeFile(this->astree(), parts[parts.size() - 1]);
+    std::shared_ptr<FileTreeEntry> entry = tree->makeFile(tree->astree(), parts[parts.size() - 1]);
 
     // If makeFile returns a null pointer, it means we cannot create file:
     if (entry == nullptr) {

--- a/src/ifiletree.h
+++ b/src/ifiletree.h
@@ -638,16 +638,19 @@ namespace MOBase {
     /**
      * @brief Create a new file directly under this tree.
      *
-     * This method will return a null pointer if the file already exists. This method
-     * invalidates iterators to this tree and all the subtrees present in the
-     * given path.
+     * This method will return a null pointer if the file already exists and if 
+     * replaceIfExists is false. This method invalidates iterators to this tree and 
+     * all the subtrees present in the given path.
      *
      * @param name Name of the file.
+     * @param replaceIfExists If true and an entry already exists at the given path,
+     *     it will be replaced by a new entry. This will replace both files and
+     *     directories.
      *
      * @return the entry corresponding to the create file, or a null
      *     pointer if the file was not created.
      */
-    virtual std::shared_ptr<FileTreeEntry> addFile(QString path);
+    virtual std::shared_ptr<FileTreeEntry> addFile(QString path, bool replaceIfExists = false);
 
     /**
      * @brief Create a new directory tree under this tree.

--- a/src/iinstallationmanager.h
+++ b/src/iinstallationmanager.h
@@ -43,6 +43,11 @@ public:
   virtual ~IInstallationManager() {}
 
   /**
+   * @return the extensions of archives supported by this installation manager.
+   */
+  virtual QStringList getSupportedExtensions() const = 0;
+
+  /**
    * @brief Extract the specified file from the currently opened archive to a temporary
    * location.
    *

--- a/src/iinstallationmanager.h
+++ b/src/iinstallationmanager.h
@@ -83,6 +83,19 @@ public:
   virtual QStringList extractFiles(std::vector<std::shared_ptr<const FileTreeEntry>> const& entries) = 0;
 
   /**
+   * @brief Create a new file on the disk corresponding to the given entry.
+   *
+   * This method can be used by installer that needs to create files that are not in the original
+   * archive. At the end of the installation, if there are entries in the final tree that were used
+   * to create files, the corresponding files will be moved to the mod folder.
+   *
+   * @param entry The entry for which a temporary file should be created.
+   *
+   * @return the path to the created file, or an empty QString() if the file could not be created.
+   */
+  virtual QString createFile(std::shared_ptr<const MOBase::FileTreeEntry> entry) = 0;
+
+  /**
    * @brief Installs the given archive.
    *
    * @param modName Suggested name of the mod.

--- a/tests/test_ifiletree.cpp
+++ b/tests/test_ifiletree.cpp
@@ -498,6 +498,43 @@ TEST(IFileTreeTest, IterOperations) {
   });
 }
 
+TEST(IFileTreeTest, AddOperations) {
+  {
+    auto fileTree = FileListTree::makeTree({
+      {"a", true},
+      {"c.x", false},
+      {"e/q/c.t", false},
+      {"e/q/p", true}
+    });
+    auto map = createMapping(fileTree);
+
+    EXPECT_EQ(fileTree->addFile("a"), nullptr);
+    EXPECT_EQ(fileTree->addFile("c.x"), nullptr);
+    EXPECT_EQ(fileTree->addFile("e"), nullptr);
+    EXPECT_EQ(fileTree->addFile("e/q"), nullptr);
+    EXPECT_EQ(fileTree->addFile("e/q/c.t"), nullptr);
+    EXPECT_EQ(fileTree->addFile("e/q/p"), nullptr);
+
+    auto a_p = fileTree->addFile("a/p");
+    EXPECT_NE(a_p, nullptr);
+    EXPECT_EQ(a_p->parent(), map["a"]);
+    
+    auto e_q_ct = fileTree->addFile("e/q/c.t", true);
+    EXPECT_NE(e_q_ct, nullptr);
+    EXPECT_EQ(e_q_ct->parent(), map["e/q"]);
+    EXPECT_EQ(map["e/q/c.t"]->parent(), nullptr);
+    EXPECT_EQ(map["e/q"]->astree()->size(), std::size_t{ 2 });
+
+    // Directory are replaced with addFile():
+    auto e_q = fileTree->addFile("e/q", true);
+    EXPECT_NE(e_q, nullptr);
+    EXPECT_EQ(e_q->parent(), map["e"]);
+    EXPECT_EQ(map["e/q"]->parent(), nullptr);
+    EXPECT_EQ(map["e"]->astree()->size(), std::size_t{ 1 });
+  }
+
+}
+
 TEST(IFileTreeTest, TreeInsertOperations) {
 
   // Test failure:


### PR DESCRIPTION
**Major:**

- Add a `createFile()` method in `IInstallationManager` that can be used to create files during installation that will then be moved to the mod folder.

As you probably know, this is an issue I had with the C# FOMOD installer. Using the simple installer interface is enough, but files need to be created.

The interface is simple and does not impact existing installers. The files are created in the temporary directory and automatically removed at the end of the installation process.

**Minor:**

- Fix a bug in `addFile` when creating files in subtrees.
- Add `replaceIfExists` in `addFile` that allow replacing existing files.
- A bit more tests for `IFileTree`.