### PR TITLE
Make IFileTree::copy() return the new entry instead of bool.

### DIFF
--- a/src/ifiletree.cpp
+++ b/src/ifiletree.cpp
@@ -350,11 +350,15 @@ namespace MOBase {
   /**
    *
    */
-  bool IFileTree::copy(std::shared_ptr<const FileTreeEntry> entry, QString path, InsertPolicy insertPolicy) {
+  std::shared_ptr<FileTreeEntry> IFileTree::copy(std::shared_ptr<const FileTreeEntry> entry, QString path, InsertPolicy insertPolicy) {
     // Note: If a conflict exists, the tree is cloned before checking the conflict, so this is not the
     // most efficient way but copying tree should be pretty rare (and probably avoided anyway), and this 
     // allow us to use `move()` to do all the complex operations.
-    return move(entry->clone(), path, insertPolicy);
+    auto clone = entry->clone();
+    if (move(clone, path, insertPolicy)) {
+      return clone;
+    }
+    return nullptr;
   }
 
   /**

--- a/src/ifiletree.h
+++ b/src/ifiletree.h
@@ -766,9 +766,9 @@ namespace MOBase {
      *     it.
      * @param insertPolicy Policy to use on conflict.
      *
-     * @return true if the entry was copied correctly, false otherwize.
+     * @return the copy of the entry if it was copied correctly, a null pointer otherwise.
      */
-    bool copy(std::shared_ptr<const FileTreeEntry> entry, QString path = "", InsertPolicy insertPolicy = InsertPolicy::FAIL_IF_EXISTS);
+    std::shared_ptr<FileTreeEntry> copy(std::shared_ptr<const FileTreeEntry> entry, QString path = "", InsertPolicy insertPolicy = InsertPolicy::FAIL_IF_EXISTS);
 
     /**
      * @brief Delete the given entry.


### PR DESCRIPTION
When I first added `copy()`, I make it returned a `bool` similar to `move()`. This is very inconvenient because you do not have access to the copy after the call.

This change it so that the cloned entry is returned. This should have 0 impact on other projects since the `shared_ptr` is implicitly convertible to `bool` anyway.