### PR TITLE
Log errors

### DIFF
--- a/src/report.cpp
+++ b/src/report.cpp
@@ -34,6 +34,7 @@ namespace MOBase
 
 void reportError(const QString &message)
 {
+  log::error("{}", message);
   if (QApplication::topLevelWidgets().count() != 0) {
     QMessageBox messageBox(QMessageBox::Warning, QObject::tr("Error"), message, QMessageBox::Ok);
     messageBox.exec();


### PR DESCRIPTION
There *might* be some places where this causes the error to be logged twice, but definitely eliminates some where it was never logged.

Most recent discussion is here: https://discordapp.com/channels/265929299490635777/412414009694748693/728288794729775134