### PR TITLE
Cherry picked: forEachLineInFile() lowercase 

### DIFF
--- a/src/utility.h
+++ b/src/utility.h
@@ -624,7 +624,7 @@ bool forEachLineInFile(const QString& filePath, F&& f)
           }
           ++lineEnd;
 
-          f(QString::fromUtf8(lineStart, lineEnd - lineStart).toLower());
+          f(QString::fromUtf8(lineStart, lineEnd - lineStart));
         }
       }
     }


### PR DESCRIPTION
it was confusing for the callers, which have been fixed for the new behaviour