### PR TITLE
Add IPluginInstaller onInstallationStart and onInstallationEnd callbacks.

### DIFF
--- a/src/iplugininstaller.h
+++ b/src/iplugininstaller.h
@@ -22,10 +22,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #ifndef IPLUGININSTALLER_H
 #define IPLUGININSTALLER_H
 
+#include <set>
 
 #include "iplugin.h"
+#include "imodinterface.h"
 #include "ifiletree.h"
-#include <set>
 
 namespace MOBase {
 
@@ -53,43 +54,81 @@ public:
   IPluginInstaller() : m_ParentWidget(nullptr), m_InstallationManager(nullptr) {}
 
   /**
-   * retrieve the priority of this installer. If multiple installers are able
+   * @brief Retrieve the priority of this installer. If multiple installers are able
    * to handle an archive, the one with the highest priority wins.
-   * @return the priority of the installer
+   *
+   * @return the priority of this installer.
    */
   virtual unsigned int priority() const = 0;
 
   /**
    * @return true if this plugin should be treated as a manual installer if the user
    * explicitly requested one. A manual installer should offer the user maximum amount of
-   * customizability
+   * customizability.
    */
   virtual bool isManualInstaller() const = 0;
 
   /**
-   * @brief test if the archive represented by the tree parameter can be installed through this installer
-   * @param tree a directory tree representing the archive
-   * @return true if this installer can handle the archive
+   * @brief Method calls at the start of the installation process, before any other methods.
+   *     This method is only called once per installation process, even for recursive
+   *     installations (e.g. with the bundle installer).
+   *
+   * @param archive Path to the archive that is going to be installed.
+   * @param mod If this is a re-installation, the currently installed mod, otherwise a null
+   *     pointer.
+   *
+   * @note The default implementation does nothing.
+   */
+  virtual void onInstallationStart(QString const& archive, IModInterface* currentMod) { }
+
+  /**
+   * @brief Method calls at the end of the installation process. This method is only called once
+   *     per installation process, even for recursive installations (e.g. with the bundle installer).
+   *
+   * @param result The result of the installation.
+   * @param mod If the installation succeeded (result is RESULT_SUCCESS), contains the newly
+   *     installed mod, otherwise it contains a null pointer.
+   *
+   * @note The default implementation does nothing.
+   */
+  virtual void onInstallationEnd(EInstallResult result, IModInterface* newMod) { }
+
+  /**
+   * @brief Test if the archive represented by the tree parameter can be installed through this 
+   *     installer.
+   *
+   * @param tree a directory tree representing the archive.
+   *
+   * @return true if this installer can handle the archive.
    */
   virtual bool isArchiveSupported(std::shared_ptr<const IFileTree> tree) const = 0;
 
   /**
-   * @brief sets the widget that the tool should use as the parent whenever
-   *        it creates a new modal dialog
-   * @param widget the new parent widget
+   * @brief Sets the widget that the tool should use as the parent whenever
+   *        it creates a new modal dialog.
+   *
+   * @param widget The new parent widget.
    */
   virtual void setParentWidget(QWidget *widget) { m_ParentWidget = widget; }
 
   /**
-   * brief sets the installation manager responsible for the installation process
-   * it can be used by plugins to access utility functions
-   * @param manager the new installation manager
+   * @brief Sets the installation manager responsible for the installation process
+   * it can be used by plugins to access utility functions.
+   *
+   * @param manager The new installation manager.
    */
   void setInstallationManager(IInstallationManager *manager) { m_InstallationManager = manager; }
 
 protected:
 
+  /**
+   * @return the parent widget that the tool should use to create new dialogs and widgets.
+   */
   QWidget *parentWidget() const { return m_ParentWidget; }
+
+  /**
+   * @return the manager responsible for the installation process.
+   */
   IInstallationManager *manager() const { return m_InstallationManager; }
 
 private:

--- a/src/iplugininstaller.h
+++ b/src/iplugininstaller.h
@@ -74,17 +74,17 @@ public:
    *     installations (e.g. with the bundle installer).
    *
    * @param archive Path to the archive that is going to be installed.
-   * @param mod If this is a re-installation, the currently installed mod, otherwise a null
-   *     pointer.
+   * @param reinstallation True if this is a reinstallation, false otherwise.
+   * @param mod A currently installed mod corresponding to the archive being installed, or a null
+   *     if there is no such mod.
    *
-   * @note MO2 can specify a mod in two situations: 1) when the user wants to re-install a mod, in
-   *     which case the given mod is the mod selected by the user, 2) when the user installs a mod
-   *     from the download panel, and a corresponding mod is already installed. Plugin should not
-   *     assume the IModInterface corresponds to the same mod as the one being installed and should
-   *     take extra precautions for this.
+   * @note If `reinstallation` is true, then the given mod is the mod being reinstalled (the one
+   *     selected by the user). If `reinstallation` is false and `currentMod` is not null, then
+   *     it corresponds to a mod MO2 thinks corresponds to the archive (e.g. based on matching Nexus ID
+   *     or name).
    * @note The default implementation does nothing.
    */
-  virtual void onInstallationStart(QString const& archive, IModInterface* currentMod) { }
+  virtual void onInstallationStart(QString const& archive, bool reinstallation, IModInterface* currentMod) { }
 
   /**
    * @brief Method calls at the end of the installation process. This method is only called once

--- a/src/iplugininstaller.h
+++ b/src/iplugininstaller.h
@@ -77,6 +77,11 @@ public:
    * @param mod If this is a re-installation, the currently installed mod, otherwise a null
    *     pointer.
    *
+   * @note MO2 can specify a mod in two situations: 1) when the user wants to re-install a mod, in
+   *     which case the given mod is the mod selected by the user, 2) when the user installs a mod
+   *     from the download panel, and a corresponding mod is already installed. Plugin should not
+   *     assume the IModInterface corresponds to the same mod as the one being installed and should
+   *     take extra precautions for this.
    * @note The default implementation does nothing.
    */
   virtual void onInstallationStart(QString const& archive, IModInterface* currentMod) { }


### PR DESCRIPTION
I added these callbacks to be able to get information from a previously installed mod (in case of re-installation) and to be able to modify settings of the mod afterwards (following https://github.com/ModOrganizer2/modorganizer-uibase/pull/84). This allows for the following (very useful !) features:

- The bundle installer will be able to easily set the true installation file at the end of the installation. Currently the installation file stored in the `meta.ini` is the extracted archive.
- This will allow some installers to remember settings from previous installation. For BAIN and Bundle (in case of multiple archives), this is pretty easy to implement. For FOMOD, this would require a bit more work and probably some refactoring.

Why two new callbacks instead of modifying the existing `install()`?

- `install()` can be called multiple times on different installers sometimes, e.g. when the bundle installer is used, and I did not want multiple callbacks for this case. These callbacks are called exactly once per "installation process".
- The installation manager does not have access to the `IModInterface` object, either before or after the installation, which makes it difficult to call the callbacks from the installation manager. Moving the calls to the place where the installation actually starts / ends fixes the problem.

Related PRs:
- `modorganizer`: https://github.com/ModOrganizer2/modorganizer/pull/1238
- `plugin_python`: https://github.com/ModOrganizer2/modorganizer-plugin_python/pull/64