### PR TITLE
Add IProfile::iniFilePath().

### DIFF
--- a/src/iprofile.h
+++ b/src/iprofile.h
@@ -20,19 +20,20 @@ public:
   virtual bool invalidationActive(bool *supported) const = 0;
 
   /**
-   * @brief Retrieve the absolute file to the corresponding file.
+   * @brief Retrieve the absolute file path to the corresponding INI file for this
+   *     profile.
    *
    * @param iniFile INI file to retrieve a path for. This can either be the
    *     name of a file or a path to the absolute file outside of the profile.
    *
    * @return the absolute path for the given INI file for this profile.
    *
-   * @note If iniFile does not correspond to a file in the list of ini files for the 
+   * @note If iniFile does not correspond to a file in the list of INI files for the 
    *     current game (as returned by IPluginGame::iniFiles), the path to the global 
    *     file will be returned (if iniFile is absolute, iniFile is returned, otherwiise 
          the path is assumed relative to the game documents directory).
    */
-  virtual QString iniFilePath(QString iniFile) const = 0;
+  virtual QString absoluteIniFilePath(QString iniFile) const = 0;
 };
 
 } // namespace MOBase

--- a/src/iprofile.h
+++ b/src/iprofile.h
@@ -26,6 +26,11 @@ public:
    *     name of a file or a path to the absolute file outside of the profile.
    *
    * @return the absolute path for the given INI file for this profile.
+   *
+   * @note If iniFile does not correspond to a file in the list of ini files for the 
+   *     current game (as returned by IPluginGame::iniFiles), the path to the global 
+   *     file will be returned (if iniFile is absolute, iniFile is returned, otherwiise 
+         the path is assumed relative to the game documents directory).
    */
   virtual QString iniFilePath(QString iniFile) const = 0;
 };

--- a/src/iprofile.h
+++ b/src/iprofile.h
@@ -27,7 +27,7 @@ public:
    *
    * @return the absolute path for the given INI file for this profile.
    */
-  virtual QString iniFilePath(QString iniFile) = 0;
+  virtual QString iniFilePath(QString iniFile) const = 0;
 };
 
 } // namespace MOBase

--- a/src/iprofile.h
+++ b/src/iprofile.h
@@ -18,6 +18,16 @@ public:
   virtual bool localSavesEnabled() const = 0;
   virtual bool localSettingsEnabled() const = 0;
   virtual bool invalidationActive(bool *supported) const = 0;
+
+  /**
+   * @brief Retrieve the absolute file to the corresponding file.
+   *
+   * @param iniFile INI file to retrieve a path for. This can either be the
+   *     name of a file or a path to the absolute file outside of the profile.
+   *
+   * @return the absolute path for the given INI file for this profile.
+   */
+  virtual QString iniFilePath(QString iniFile) = 0;
 };
 
 } // namespace MOBase


### PR DESCRIPTION
After allowing absolute file path in `IPluginGame::iniFiles()`, it becomes annoying to get the path to a INI file depending on the local INI setting, so I'm adding this.