### PR TITLE
Filter widget sometimes ignores source sorting

### DIFF
--- a/src/filterwidget.cpp
+++ b/src/filterwidget.cpp
@@ -71,6 +71,10 @@ bool FilterWidgetProxyModel::columnMatches(
 void FilterWidgetProxyModel::sort(int column, Qt::SortOrder order)
 {
   if (m_filter.useSourceSort()) {
+    // without this, the proxy seems to sometimes ignore the sorting done below,
+    // no idea why
+    QSortFilterProxyModel::sort(-1, order);
+
     sourceModel()->sort(column, order);
   } else {
     QSortFilterProxyModel::sort(column, order);


### PR DESCRIPTION
No clue on this one. Sorting is sometimes ignored by the underlying proxy model unless the sort order is set. The column needs to be `-1` to avoid double sorts, I think. I don't know. The sort proxy strikes again.