### PR TITLE
Command line and instance dialogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ CMakeLists.txt.user
 /msbuild.log
 /*std*.log
 /*build
+/src/uibasetests_en.ts

--- a/src/filterwidget.cpp
+++ b/src/filterwidget.cpp
@@ -221,11 +221,6 @@ QAbstractItemModel* FilterWidget::sourceModel()
   }
 }
 
-QModelIndex FilterWidget::map(const QModelIndex& index)
-{
-  return mapToSource(index);
-}
-
 QModelIndex FilterWidget::mapFromSource(const QModelIndex& index) const
 {
   if (m_proxy) {

--- a/src/filterwidget.cpp
+++ b/src/filterwidget.cpp
@@ -420,6 +420,26 @@ void FilterWidget::unhookList()
   m_shortcuts.clear();
 }
 
+// walks up the parents of `w`, returns true if one of them is a QDialog
+//
+bool topLevelIsDialog(QWidget* w)
+{
+  if (!w) {
+    return false;
+  }
+
+  auto* p = w->parentWidget();
+  while (p) {
+    if (dynamic_cast<QDialog*>(p)) {
+      return true;
+    }
+
+    p = p->parentWidget();
+  }
+
+  return false;
+}
+
 void FilterWidget::setShortcuts()
 {
   auto activate = [this] {
@@ -447,14 +467,26 @@ void FilterWidget::setShortcuts()
   };
 
 
+  // don't hook the escape key for reset when the filter is in a dialog, the
+  // standard behaviour is to close the dialog
+  const bool inDialog = topLevelIsDialog(
+    m_list ? static_cast<QWidget*>(m_list) : m_edit);
+
+
   if (m_list) {
     hookActivate(m_list);
-    hookReset(m_list);
+
+    if (!inDialog) {
+      hookReset(m_list);
+    }
   }
 
   if (m_edit) {
     hookActivate(m_edit);
-    hookReset(m_edit);
+
+    if (!inDialog) {
+      hookReset(m_edit);
+    }
   }
 }
 

--- a/src/filterwidget.cpp
+++ b/src/filterwidget.cpp
@@ -88,7 +88,7 @@ FilterWidget::FilterWidget() :
   m_edit(nullptr), m_list(nullptr), m_proxy(nullptr),
   m_eventFilter(nullptr), m_clear(nullptr), m_timer(nullptr),
   m_valid(true), m_useSourceSort(false), m_filterColumn(-1),
-  m_filteringEnabled(true)
+  m_filteringEnabled(true), m_filteredBorder(true)
 {
   m_timer = new QTimer(this);
   m_timer->setSingleShot(true);
@@ -195,18 +195,74 @@ bool FilterWidget::filteringEnabled() const
   return m_filteringEnabled;
 }
 
+void FilterWidget::setFilteredBorder(bool b)
+{
+  m_filteredBorder = b;
+}
+
+bool FilterWidget::filteredBorder() const
+{
+  return m_filteredBorder;
+}
+
 FilterWidgetProxyModel* FilterWidget::proxyModel()
 {
   return m_proxy;
 }
 
+QAbstractItemModel* FilterWidget::sourceModel()
+{
+  if (m_proxy) {
+    return m_proxy->sourceModel();
+  } else if (m_list) {
+    return m_list->model();
+  } else {
+    return nullptr;
+  }
+}
+
 QModelIndex FilterWidget::map(const QModelIndex& index)
+{
+  return mapToSource(index);
+}
+
+QModelIndex FilterWidget::mapFromSource(const QModelIndex& index) const
+{
+  if (m_proxy) {
+    return m_proxy->mapFromSource(index);
+  } else {
+    log::error("FilterWidget::mapFromSource() called, but proxy isn't set up");
+    return index;
+  }
+}
+
+QModelIndex FilterWidget::mapToSource(const QModelIndex& index) const
 {
   if (m_proxy) {
     return m_proxy->mapToSource(index);
   } else {
-    log::error("FilterWidget::map() called, but proxy isn't set up");
+    log::error("FilterWidget::mapToSource() called, but proxy isn't set up");
     return index;
+  }
+}
+
+QItemSelection FilterWidget::mapSelectionFromSource(const QItemSelection& sel) const
+{
+  if (m_proxy) {
+    return m_proxy->mapSelectionFromSource(sel);
+  } else {
+    log::error("FilterWidget::mapToSource() called, but proxy isn't set up");
+    return sel;
+  }
+}
+
+QItemSelection FilterWidget::mapSelectionToSource(const QItemSelection& sel) const
+{
+  if (m_proxy) {
+    return m_proxy->mapSelectionToSource(sel);
+  } else {
+    log::error("FilterWidget::mapToSource() called, but proxy isn't set up");
+    return sel;
   }
 }
 
@@ -301,6 +357,13 @@ bool FilterWidget::matches(predFun pred) const
   }
 
   return false;
+}
+
+bool FilterWidget::matches(const QString& s) const
+{
+  return matches([&](const QRegularExpression& re) {
+    return re.match(s).hasMatch();
+  });
 }
 
 void FilterWidget::hookEdit()
@@ -451,7 +514,10 @@ void FilterWidget::set()
   }
 
   if (m_list) {
-    setStyleProperty(m_list, "filtered", !m_text.isEmpty());
+    if (m_filteredBorder) {
+      setStyleProperty(m_list, "filtered", !m_text.isEmpty());
+    }
+
     scrollToSelection();
   }
 

--- a/src/filterwidget.h
+++ b/src/filterwidget.h
@@ -75,11 +75,22 @@ public:
   void setFilteringEnabled(bool b);
   bool filteringEnabled() const;
 
-  FilterWidgetProxyModel* proxyModel();
+  void setFilteredBorder(bool b);
+  bool filteredBorder() const;
 
+  FilterWidgetProxyModel* proxyModel();
+  QAbstractItemModel* sourceModel();
+
+  [[deprecated("use mapToSource()")]]
   QModelIndex map(const QModelIndex& index);
 
+  QModelIndex mapFromSource(const QModelIndex& index) const;
+  QModelIndex mapToSource(const QModelIndex& index) const;
+  QItemSelection mapSelectionFromSource(const QItemSelection& sel) const;
+  QItemSelection mapSelectionToSource(const QItemSelection& sel) const;
+
   bool matches(predFun pred) const;
+  bool matches(const QString& s) const;
 
 signals:
   void aboutToChange(const QString& oldFilter, const QString& newFilter);
@@ -102,6 +113,7 @@ private:
   bool m_useSourceSort;
   int m_filterColumn;
   bool m_filteringEnabled;
+  bool m_filteredBorder;
 
   void hookEdit();
   void unhookEdit();

--- a/src/filterwidget.h
+++ b/src/filterwidget.h
@@ -81,9 +81,6 @@ public:
   FilterWidgetProxyModel* proxyModel();
   QAbstractItemModel* sourceModel();
 
-  [[deprecated("use mapToSource()")]]
-  QModelIndex map(const QModelIndex& index);
-
   QModelIndex mapFromSource(const QModelIndex& index) const;
   QModelIndex mapToSource(const QModelIndex& index) const;
   QItemSelection mapSelectionFromSource(const QItemSelection& sel) const;

--- a/src/imoinfo.cpp
+++ b/src/imoinfo.cpp
@@ -1,0 +1,24 @@
+#include "imoinfo.h"
+
+namespace MOBase
+{
+
+static QString g_pluginDataPath;
+
+QString IOrganizer::getPluginDataPath()
+{
+  return g_pluginDataPath;
+}
+
+} // namespace
+
+
+namespace MOBase::details
+{
+
+void setPluginDataPath(const QString& s)
+{
+  g_pluginDataPath = s;
+}
+
+}

--- a/src/imoinfo.h
+++ b/src/imoinfo.h
@@ -45,9 +45,26 @@ class IPluginGame;
 /**
  * @brief Interface to class that provides information about the running session
  *        of Mod Organizer to be used by plugins
+ *
+ * When MO requires plugins but does not have a valid instance loaded (such as
+ * on first start in the instance creation dialog), init() will not be called at
+ * all, except for proxy plugins.
+ *
+ * In the case of proxy plugins, init() is called with an IOrganizer that has
+ * reduced capabilities. All functions may be called, but most of them will
+ * return empty values.
+ *
+ * In particular, these functions are guaranteed to return useful information:
+ *    - appVersion()
+ *    - pluginDataPath()
+ *
+ * All setting related functions (persistent(), pluginSetting(), etc.) will
+ * return empty variants for getters and will be no-ops for setters.
  */
-class QDLLEXPORT IOrganizer: public QObject {
+class QDLLEXPORT IOrganizer: public QObject
+{
   Q_OBJECT
+
 public:
 
   /**

--- a/src/imoinfo.h
+++ b/src/imoinfo.h
@@ -50,16 +50,7 @@ class IPluginGame;
  * on first start in the instance creation dialog), init() will not be called at
  * all, except for proxy plugins.
  *
- * In the case of proxy plugins, init() is called with an IOrganizer that has
- * reduced capabilities. All functions may be called, but most of them will
- * return empty values.
- *
- * In particular, these functions are guaranteed to return useful information:
- *    - appVersion()
- *    - pluginDataPath()
- *
- * All setting related functions (persistent(), pluginSetting(), etc.) will
- * return empty variants for getters and will be no-ops for setters.
+ * In the case of proxy plugins, init() is called with a null IOrganizer.
  */
 class QDLLEXPORT IOrganizer: public QObject
 {
@@ -77,8 +68,11 @@ public:
   };
 
 public:
-
   virtual ~IOrganizer() {}
+
+  // the directory for plugin data, typically plugins/data
+  //
+  static QString getPluginDataPath();
 
   /**
    * @return create a new nexus interface class
@@ -444,5 +438,12 @@ public:
 };
 
 } // namespace MOBase
+
+
+namespace MOBase::details
+{
+  // called from MO
+  QDLLEXPORT void setPluginDataPath(const QString& s);
+}
 
 #endif // IMOINFO_H

--- a/src/imoinfo.h
+++ b/src/imoinfo.h
@@ -109,7 +109,7 @@ public:
    * @return an interface that can be used to modify the mod. nullptr if the user canceled
    * @note a popup asking the user to merge, rename or replace the mod is displayed if the mod already exists.
    *       That has to happen on the main thread and MO2 will deadlock if it happens on any other.
-   *       If this needs to be called from another thread, use "getMod" to verify the mod-name is unused first
+   *       If this needs to be called from another thread, use IModList::getMod() to verify the mod-name is unused first
    */
   virtual IModInterface *createMod(GuessedValue<QString> &name) = 0;
 
@@ -307,7 +307,7 @@ public:
       HANDLE handle, LPDWORD exitCode = nullptr) const = 0;
 
   /**
-   * @brief Refresh the internal mods file structure from disk. This includes the mod list, the plugin  
+   * @brief Refresh the internal mods file structure from disk. This includes the mod list, the plugin
    *     list, data tab and other smaller things like problems button (same as pressing F5).
    *
    * @note The main part of the refresh of the mods file strcuture, modlist and pluginlist is done

--- a/src/iplugin.h
+++ b/src/iplugin.h
@@ -31,24 +31,46 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 namespace MOBase {
 
-class IPlugin {
+class IPlugin
+{
 public:
   virtual ~IPlugin() {}
 
-  /** 
-   * @brief Initialize the plugin. This is called immediately after loading the plugin,
-   *     no other function is called before. Plugins will probably want to store the
-   *     organizer pointer. It is guaranteed to be valid as long as the plugin is loaded.
+  /**
+  * @brief Called after the plugin has been created and registered in MO, but
+  *        before init()
+  *
+  * This function will always be called on plugins just after they load, but
+  * note that init() may never be called.
+  */
+  virtual void registered() {}
+
+  /**
+   * @brief Initialize the plugin. This is called after registered().
    *
-   * @return false if the plugin could not be initialized, true otherwise. 
+   * Note that this function may never be called if no IOrganizer is available
+   * at that time, such as when creating the first instance in MO. For proxy
+   * plugins, init() is always called, but the given IOrganizer will have
+   * reduced capabilities. See IOrganizer.
+   *
+   * Plugins will probably want to store the organizer pointer. It is guaranteed
+   * to be valid as long as the plugin is loaded.
+   *
+   * These functions may be called before init():
+   *   - name()
+   *   - see IPluginGame for more
+   *
+   * @return false if the plugin could not be initialized, true otherwise.
    */
   virtual bool init(IOrganizer *organizer) = 0;
 
   /**
+   * this function may be called before init()
+   *
    * @return the internal name of this plugin (used for example in the settings menu).
    *
-   * @note Please ensure you use a name that will not change. Do NOT include a version number in the 
-   *     name. Do NOT use a localizable string (tr()) here. Settings for example are tied to this name, 
+   * @note Please ensure you use a name that will not change. Do NOT include a version number in the
+   *     name. Do NOT use a localizable string (tr()) here. Settings for example are tied to this name,
    *     if you rename your plugin you lose settings users made.
    */
   virtual QString name() const = 0;
@@ -56,13 +78,13 @@ public:
   /**
    * @return the localized name for this plugin.
    *
-   * @note Unlike name(), this method can (and should!) return a localized name for the plugin. 
+   * @note Unlike name(), this method can (and should!) return a localized name for the plugin.
    * @note This method returns name() by default.
    */
   virtual QString localizedName() const { return name(); }
 
   /**
-   * @brief Retrieve the master plugin of this plugin. 
+   * @brief Retrieve the master plugin of this plugin.
    *
    * It is often easier to implement a functionality as multiple plugins in MO2, but ship the
    * plugins together, e.g. as a Python module or using `createFunctions()`. In this case, having
@@ -99,7 +121,7 @@ public:
   virtual bool isActive() const = 0;
 
   /**
-   * @return the list of configurable settings for this plugin (in the user interface). The list may be 
+   * @return the list of configurable settings for this plugin (in the user interface). The list may be
    *     empty.
    *
    * @note Plugin can store "hidden" (from the user) settings using IOrganizer::persistent / IOrganizer::setPersistent.

--- a/src/iplugin.h
+++ b/src/iplugin.h
@@ -50,8 +50,7 @@ public:
    *
    * Note that this function may never be called if no IOrganizer is available
    * at that time, such as when creating the first instance in MO. For proxy
-   * plugins, init() is always called, but the given IOrganizer will have
-   * reduced capabilities. See IOrganizer.
+   * plugins, init() is always called, but given a null IOrganizer
    *
    * Plugins will probably want to store the organizer pointer. It is guaranteed
    * to be valid as long as the plugin is loaded.

--- a/src/iplugingame.h
+++ b/src/iplugingame.h
@@ -18,12 +18,26 @@ class QStringList;
 
 namespace MOBase {
 
-
-class IPluginGame : public QObject, public IPlugin {
+// A game plugin.
+//
+// Game plugins can be loaded without an IOrganizer being available, in which
+// case registered() is called, but not init().
+//
+// These functions may be called before init():
+//   - gameName()
+//   - isInstalled()
+//   - gameIcon()
+//   - gameDirectory()
+//   - dataDirectory()
+//   - gameVariants()
+//   - looksValid()
+//   - see IPlugin::init() for more
+//
+class IPluginGame : public QObject, public IPlugin
+{
   Q_INTERFACES(IPlugin)
 
 public:
-
   enum class LoadOrderMechanism {
     FileTime,
     PluginsTxt
@@ -42,11 +56,13 @@ public:
     SAVEGAMES       = 0x04,
     PREFER_DEFAULTS = 0x08
   };
+
   Q_DECLARE_FLAGS(ProfileSettings, ProfileSetting)
 
 public:
-
   /**
+   * this function may be called before init()
+   *
    * @return name of the game
    */
   virtual QString gameName() const = 0;
@@ -92,21 +108,29 @@ public:
   virtual QString savegameSEExtension() const = 0;
 
   /**
+   * this function may be called before init()
+   *
    * @return true if this game has been discovered as installed, false otherwise
    */
   virtual bool isInstalled() const = 0;
 
   /**
+   * this function may be called before init()
+   *
    * @return an icon for this game
    */
   virtual QIcon gameIcon() const = 0;
 
   /**
+   * this function may be called before init()
+   *
    * @return directory to the game installation
    */
   virtual QDir gameDirectory() const = 0;
 
   /**
+   * this function may be called before init()
+   *
    * @return directory where the game expects to find its data files
    */
   virtual QDir dataDirectory() const = 0;
@@ -152,6 +176,8 @@ public:
   virtual QStringList primaryPlugins() const = 0;
 
   /**
+   * this function may be called before init()
+   *
    * @return list of game variants
    * @note if there are multiple variants of a game (and the variants make a difference to the
    *       plugin) like a regular one and a GOTY-edition the plugin can return a list of them and
@@ -247,6 +273,8 @@ public:
   virtual int nexusGameID() const = 0;
 
   /**
+   * this function may be called before init()
+   *
    * @brief See if the supplied directory looks like a valid game
    */
   virtual bool looksValid(QDir const &) const = 0;

--- a/src/iplugingame.h
+++ b/src/iplugingame.h
@@ -18,8 +18,6 @@ class QStringList;
 
 namespace MOBase {
 
-// A game plugin.
-//
 // Game plugins can be loaded without an IOrganizer being available, in which
 // case registered() is called, but not init().
 //

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -58,7 +58,7 @@ TaskDialogButton::TaskDialogButton(QString t, QMessageBox::StandardButton b)
 TaskDialog::TaskDialog(QWidget* parent, QString title) :
   m_dialog(new QDialog(parent)), ui(new Ui::TaskDialog),
   m_title(std::move(title)), m_icon(QMessageBox::NoIcon),
-  m_result(QMessageBox::Cancel),
+  m_result(QMessageBox::Cancel), m_width(-1),
   m_rememberCheck(nullptr), m_rememberCombo(nullptr)
 {
   ui->setupUi(m_dialog.get());
@@ -117,6 +117,11 @@ void TaskDialog::addContent(QWidget* w)
   ly->insertWidget(ly->count() - 1, w);
 }
 
+void TaskDialog::setWidth(int w)
+{
+  m_width = w;
+}
+
 QMessageBox::StandardButton TaskDialog::exec()
 {
   const auto b = checkMemory();
@@ -130,7 +135,12 @@ QMessageBox::StandardButton TaskDialog::exec()
   setButtons();
   setDetails();
 
-  ui->topPanel->setMinimumWidth(400);
+  if (m_width >= 0) {
+    ui->topPanel->setMinimumWidth(m_width);
+  } else {
+    ui->topPanel->setMinimumWidth(400);
+  }
+
   m_dialog->adjustSize();
 
   if (m_dialog->exec() != QDialog::Accepted) {

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -109,6 +109,14 @@ TaskDialog& TaskDialog::remember(const QString& action, const QString& file)
   return *this;
 }
 
+void TaskDialog::addContent(QWidget* w)
+{
+  auto* ly = static_cast<QVBoxLayout*>(ui->contentPanel->layout());
+
+  // add before spacer
+  ly->insertWidget(ly->count() - 1, w);
+}
+
 QMessageBox::StandardButton TaskDialog::exec()
 {
   const auto b = checkMemory();
@@ -265,7 +273,9 @@ void TaskDialog::setWidgets()
 {
   ui->main->setText(m_main);
   setFontPercent(ui->main, 1.5);
+
   ui->content->setText(m_content);
+  ui->content->setVisible(!m_content.isEmpty());
 
   auto icon = standardIcon(m_icon);
 

--- a/src/report.h
+++ b/src/report.h
@@ -67,6 +67,7 @@ public:
   TaskDialog& remember(const QString& action, const QString& file={});
 
   void addContent(QWidget* w);
+  void setWidth(int w);
 
   QMessageBox::StandardButton exec();
 
@@ -78,6 +79,7 @@ private:
   std::vector<TaskDialogButton> m_buttons;
   QMessageBox::StandardButton m_result;
   std::unique_ptr<ExpanderWidget> m_expander;
+  int m_width;
 
   QString m_rememberAction, m_rememberFile;
   QCheckBox* m_rememberCheck;

--- a/src/report.h
+++ b/src/report.h
@@ -66,6 +66,8 @@ public:
   TaskDialog& button(TaskDialogButton b);
   TaskDialog& remember(const QString& action, const QString& file={});
 
+  void addContent(QWidget* w);
+
   QMessageBox::StandardButton exec();
 
 private:

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -509,10 +509,21 @@ Result Delete(const QFileInfo& path)
 
 Result Rename(const QFileInfo& src, const QFileInfo& dest)
 {
+  return Rename(src, dest, true);
+}
+
+Result Rename(const QFileInfo& src, const QFileInfo& dest, bool copyAllowed)
+{
   const auto wsrc = toUNC(src);
   const auto wdest = toUNC(dest);
 
-  if (!::MoveFileEx(wsrc.c_str(), wdest.c_str(), MOVEFILE_COPY_ALLOWED)) {
+  DWORD flags = 0;
+
+  if (copyAllowed) {
+    flags |= MOVEFILE_COPY_ALLOWED;
+  }
+
+  if (!::MoveFileEx(wsrc.c_str(), wdest.c_str(), flags)) {
     const auto e = ::GetLastError();
     return Result::makeFailure(e);
   }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -33,6 +33,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <QTextCodec>
 #include <QtDebug>
 #include <QUuid>
+#include <QCollator>
 #include <QtWinExtras/QtWin>
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
@@ -649,6 +650,33 @@ QString ToString(const SYSTEMTIME &time)
   GetDateFormatA(LOCALE_USER_DEFAULT, LOCALE_USE_CP_ACP, &time, nullptr, dateBuffer, size);
   GetTimeFormatA(LOCALE_USER_DEFAULT, LOCALE_USE_CP_ACP, &time, nullptr, timeBuffer, size);
   return QString::fromLocal8Bit(dateBuffer) + " " + QString::fromLocal8Bit(timeBuffer);
+}
+
+static int naturalCompareI(const QString& a, const QString& b)
+{
+  static QCollator c = []{
+    QCollator temp;
+    temp.setNumericMode(true);
+    temp.setCaseSensitivity(Qt::CaseInsensitive);
+    return temp;
+  }();
+
+  return c.compare(a, b);
+}
+
+int naturalCompare(const QString& a, const QString& b, Qt::CaseSensitivity cs)
+{
+  if (cs == Qt::CaseInsensitive) {
+    return naturalCompareI(a, b);
+  }
+
+  static QCollator c = []{
+    QCollator temp;
+    temp.setNumericMode(true);
+    return temp;
+  }();
+
+  return c.compare(a, b);
 }
 
 bool fixDirectoryName(QString &name)

--- a/src/utility.h
+++ b/src/utility.h
@@ -267,6 +267,9 @@ namespace shell
   // across volumes
   //
   QDLLEXPORT Result Rename(const QFileInfo& src, const QFileInfo& dest);
+
+  QDLLEXPORT Result CreateDirectories(const QDir& dir);
+  QDLLEXPORT Result DeleteDirectoryRecursive(const QDir& dir);
 }
 
 /**

--- a/src/utility.h
+++ b/src/utility.h
@@ -403,6 +403,34 @@ QDLLEXPORT QString ToQString(const std::wstring &source);
  **/
 QDLLEXPORT QString ToString(const SYSTEMTIME &time);
 
+
+// three-way compare for natural sorting (case insensitive default, 10 comes
+// after 2)
+//
+QDLLEXPORT int naturalCompare(
+  const QString& a, const QString& b,
+  Qt::CaseSensitivity cs=Qt::CaseInsensitive);
+
+
+// calls naturalCompare()
+//
+class QDLLEXPORT NaturalSort
+{
+public:
+  NaturalSort(Qt::CaseSensitivity cs=Qt::CaseInsensitive)
+    : m_cs(cs)
+  {
+  }
+
+  bool operator()(const QString& a, const QString& b)
+  {
+    return (naturalCompare(a, b, m_cs) < 0);
+  }
+
+private:
+  Qt::CaseSensitivity m_cs;
+};
+
 /**
  * throws on failure
  * @param id    the folder id

--- a/src/utility.h
+++ b/src/utility.h
@@ -267,6 +267,7 @@ namespace shell
   // across volumes
   //
   QDLLEXPORT Result Rename(const QFileInfo& src, const QFileInfo& dest);
+  QDLLEXPORT Result Rename(const QFileInfo& src, const QFileInfo& dest, bool copyAllowed);
 
   QDLLEXPORT Result CreateDirectories(const QDir& dir);
   QDLLEXPORT Result DeleteDirectoryRecursive(const QDir& dir);


### PR DESCRIPTION
### Shell
- Added `CreateDirectories()`, `DeleteDirectoryRecursive()`
- Added `Rename()` with a `copyAllowed` flag.

### `FilterWidget`
- Added an option to disable the red border
- Added a few functions for mapping and a simpler `matches()` that just takes a string.
- Don't hook the escape key to reset filters when in a dialog, it prevents from closing it.

### `TaskDialog`
- Added `addContent()` to add custom content at the bottom of the dialog
- Added `setWidth()` to override the default width

### Stuff
- Moved `naturalCompare()` from MO
