### PR TITLE
Raise the `TaskDialog` on top if there's no parent

### DIFF
--- a/src/report.cpp
+++ b/src/report.cpp
@@ -143,6 +143,13 @@ QMessageBox::StandardButton TaskDialog::exec()
 
   m_dialog->adjustSize();
 
+  if (!m_dialog->parent()) {
+    // no parent, make sure it's shown on top
+    m_dialog->show();
+    m_dialog->activateWindow();
+    m_dialog->raise();
+  }
+
   if (m_dialog->exec() != QDialog::Accepted) {
     return QMessageBox::Cancel;
   }


### PR DESCRIPTION
Happens when dialogs are shown without a main window, they would sometimes be shown in the back of the z order.