### PR TITLE
IPluginGame::listSaves

### DIFF
--- a/src/ifiletree.cpp
+++ b/src/ifiletree.cpp
@@ -7,7 +7,7 @@
 namespace MOBase {
   FileTreeEntry::FileTreeEntry(std::shared_ptr<const IFileTree> parent, QString name) :
     m_Parent(parent), m_Name(name) { }
-  
+
   QString FileTreeEntry::suffix() const {
     const int idx = m_Name.lastIndexOf(".");
     return (isDir() || idx == -1) ? "" : m_Name.mid(idx + 1);
@@ -81,7 +81,7 @@ namespace MOBase {
   };
 
   /**
-   * @brief Comparator that can be used to find entry matching the given name and 
+   * @brief Comparator that can be used to find entry matching the given name and
    *     file type.
    */
   struct MatchEntryComparator {
@@ -125,7 +125,7 @@ namespace MOBase {
 
 
     std::stack<std::pair<QString, std::shared_ptr<const FileTreeEntry>>> stack;
-    
+
     // We start by pushing all the entries in this tree, this avoid having to do extra check later
     // for avoid leading separator:
     for (auto rit = rbegin(); rit != rend(); ++rit) {
@@ -271,7 +271,7 @@ namespace MOBase {
       insertionIt = entries().insert(insertionIt, entry);
     }
 
-    // Remove the tree from its parent (parent() can be null if we are inserting 
+    // Remove the tree from its parent (parent() can be null if we are inserting
     // a new tree):
     if (entry->parent() != nullptr) {
       entry->parent()->erase(entry);
@@ -345,14 +345,14 @@ namespace MOBase {
     }
 
     return true;
-  }  
-  
+  }
+
   /**
    *
    */
   std::shared_ptr<FileTreeEntry> IFileTree::copy(std::shared_ptr<const FileTreeEntry> entry, QString path, InsertPolicy insertPolicy) {
     // Note: If a conflict exists, the tree is cloned before checking the conflict, so this is not the
-    // most efficient way but copying tree should be pretty rare (and probably avoided anyway), and this 
+    // most efficient way but copying tree should be pretty rare (and probably avoided anyway), and this
     // allow us to use `move()` to do all the complex operations.
     auto clone = entry->clone();
     if (move(clone, path, insertPolicy)) {
@@ -461,7 +461,7 @@ namespace MOBase {
     // Using raw \\ instead of QDir::separator() since we are replacing by /
     // anyway, and this avoid pulling an extra header (like QDir) only
     // for the separator.
-    return path.replace("\\", "/").split("/", QString::SkipEmptyParts);
+    return path.replace("\\", "/").split("/", Qt::SkipEmptyParts);
   }
 
   /**
@@ -685,7 +685,7 @@ namespace MOBase {
    */
   std::shared_ptr<FileTreeEntry> IFileTree::clone() const {
     std::shared_ptr<IFileTree> tree = doClone();
-    
+
     // Don't copy not populated tree, it is not useful:
     if (m_Populated) {
       tree->m_Populated = true;

--- a/src/iplugin.h
+++ b/src/iplugin.h
@@ -97,8 +97,7 @@ public:
   /**
    * @brief Retrieve the requirements for the plugins.
    *
-   * This method is called right after init() and the ownership the requirements is
-   * transferred to MO2 so plugins should not take care of releasing the requirements.
+   * This method is called right after init().
    *
    * @return the requirements for this plugin.
    */

--- a/src/iplugin.h
+++ b/src/iplugin.h
@@ -27,6 +27,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "imoinfo.h"
 #include "pluginsetting.h"
 #include "pluginrequirements.h"
+#include <vector>
 #include <QString>
 #include <QObject>
 
@@ -101,7 +102,7 @@ public:
    *
    * @return the requirements for this plugin.
    */
-  virtual QList<IPluginRequirement*> requirements() const { return {}; }
+  virtual std::vector<std::shared_ptr<const IPluginRequirement>> requirements() const { return {}; }
 
   /**
    * @return the author of this plugin.

--- a/src/iplugingame.h
+++ b/src/iplugingame.h
@@ -3,6 +3,7 @@
 
 
 #include "iplugin.h"
+#include "isavegame.h"
 #include "executableinfo.h"
 
 class QIcon;
@@ -14,6 +15,7 @@ class QStringList;
 #include <cstdint>
 #include <typeindex>
 #include <unordered_map>
+#include <memory>
 #include <vector>
 
 namespace MOBase {
@@ -117,14 +119,16 @@ public:
   virtual void initializeProfile(const QDir &directory, ProfileSettings settings) const = 0;
 
   /**
+   * @brief List save games in the specified folder.
+   *
+   * @param folder The folder containing the saves.
+   *
+   * @return the list of saves in the specified folder.
+   */
+  /**
    * @return file extension of save games for this game
    */
-  virtual QString savegameExtension() const = 0;
-
-  /**
-   * @return file extension of script extender save game files for this game
-   */
-  virtual QString savegameSEExtension() const = 0;
+  virtual std::vector<std::shared_ptr<const ISaveGame>> listSaves(QDir folder) const = 0;
 
   /**
    * this function may be called before init()

--- a/src/iplugingame.h
+++ b/src/iplugingame.h
@@ -63,7 +63,7 @@ public:
 public:
 
   // Game plugin should not have requirements:
-  QList<IPluginRequirement*> requirements() const final override { return {}; }
+  std::vector<std::shared_ptr<const IPluginRequirement>> requirements() const final override { return {}; }
 
   /**
    * this function may be called before init()

--- a/src/isavegame.h
+++ b/src/isavegame.h
@@ -15,22 +15,30 @@ public:
   virtual ~ISaveGame() {}
 
   /**
-   * @brief get the name of the (main) save file.
+   * @return the path of the (main) save file, either as an absolute file or
+   *     relative to the save folder for which this save was created.
    */
-  virtual QString getFilename() const = 0;
+  virtual QString getFilepath() const = 0;
 
   /**
-   * @brief get the creation time of the save.
+   * @brief Retrieve the creation time of the save.
    *
    * Note that this might not be the same as the creation time of the file.
    */
   virtual QDateTime getCreationTime() const = 0;
 
   /**
-   * @brief get a name which can be used to identify sets of saves to transfer
-   * between profiles.
+   * @brief Retrieve the name of this save.
    *
-   * This is normally the pc name for RPG games.
+   * @return the name of this save.
+   */
+  virtual QString getName() const = 0;
+
+  /**
+   * @brief Get a name which can be used to identify sets of saves.
+   *
+   * This is usually the PC name for RPG games. The name can contain '/' that
+   * are considered separate section for better visualization (not yet implemented).
    */
   virtual QString getSaveGroupIdentifier() const = 0;
 
@@ -41,10 +49,6 @@ public:
    */
   virtual QStringList allFiles() const = 0;
 
-  /**
-  * @brief See if the save file has an associated script extender save
-  */
-  virtual bool hasScriptExtenderFile() const = 0;
 };
 
 }

--- a/src/isavegameinfowidget.h
+++ b/src/isavegameinfowidget.h
@@ -3,6 +3,8 @@
 
 #include <QWidget>
 
+#include "isavegame.h"
+
 class QFile;
 
 namespace MOBase {
@@ -21,7 +23,7 @@ public:
   virtual ~ISaveGameInfoWidget() {}
 
   /** Set the save file to display in the widget */
-  virtual void setSave(QString const &) = 0;
+  virtual void setSave(ISaveGame const &) = 0;
 };
 
 }

--- a/src/memoizedlock.h
+++ b/src/memoizedlock.h
@@ -1,0 +1,60 @@
+#ifndef MO_UIBASE_MEMOIZEDLOCK_INCLUDED
+#define MO_UIBASE_MEMOIZEDLOCK_INCLUDED
+
+// Do not put this in utility.h otherwise the C# projects will
+// fail to compile since apparently <mutex> is not available in
+// C++/CLI projects.
+
+#include <functional>
+#include <mutex>
+
+namespace MOBase {
+
+/**
+ * Class that can be used to perform thread-safe memoization.
+ *
+ * Each instance hold a flag indicating if the current value is up-to-date
+ * or not. This flag can be reset using `invalidate()`. When the value is queried,
+ * the flag is checked, and if it is not up-to-date, the given callback is used
+ * to compute the value.
+ *
+ * The computation and update of the value is locked to avoid concurrent modifications.
+ *
+ * @tparam T Type of value ot memoized.
+ * @tparam Fn Type of the callback.
+ */
+template <class T, class Fn = std::function<T()>>
+class MemoizedLocked {
+public:
+
+  template <class Callable>
+  MemoizedLocked(Callable&& callable, T value = {}) :
+    m_Fn{ std::forward<Callable>(callable) }, m_Value{ std::move(value) } { }
+
+  template <class... Args>
+  T& value(Args&&... args) const {
+    if (m_NeedUpdating) {
+      std::scoped_lock lock(m_Mutex);
+      if (m_NeedUpdating) {
+        m_Value = std::invoke(m_Fn, std::forward<Args>(args)...);
+        m_NeedUpdating = false;
+      }
+    }
+    return m_Value;
+  }
+
+  void invalidate() {
+    m_NeedUpdating = true;
+  }
+
+private:
+  mutable std::mutex m_Mutex;
+  mutable std::atomic<bool> m_NeedUpdating{ true };
+
+  Fn m_Fn;
+  mutable T m_Value;
+};
+
+}
+
+#endif

--- a/src/pluginrequirements.cpp
+++ b/src/pluginrequirements.cpp
@@ -104,22 +104,26 @@ private:
 
 // Factory
 
-IPluginRequirement* PluginRequirementFactory::pluginDependency(QStringList const& pluginNames)
+std::shared_ptr<const IPluginRequirement> PluginRequirementFactory::pluginDependency(
+  QStringList const& pluginNames)
 {
-  return new PluginDependencyRequirement(pluginNames);
+  return std::make_shared<PluginDependencyRequirement>(pluginNames);
 }
 
-IPluginRequirement* PluginRequirementFactory::gameDependency(QStringList const& pluginGameNames)
+std::shared_ptr<const IPluginRequirement> PluginRequirementFactory::gameDependency(
+  QStringList const& pluginGameNames)
 {
-  return new GameDependencyRequirement(pluginGameNames);
+  return std::make_shared<GameDependencyRequirement>(pluginGameNames);
 }
 
-IPluginRequirement* PluginRequirementFactory::diagnose(const IPluginDiagnose* diagnose)
+std::shared_ptr<const IPluginRequirement> PluginRequirementFactory::diagnose(
+  const IPluginDiagnose* diagnose)
 {
-  return new DiagnoseRequirement(diagnose);
+  return std::make_shared<DiagnoseRequirement>(diagnose);
 }
 
-IPluginRequirement* PluginRequirementFactory::basic(std::function<bool(IOrganizer*)> const& checker, QString const description)
+std::shared_ptr<const IPluginRequirement> PluginRequirementFactory::basic(
+  std::function<bool(IOrganizer*)> const& checker, QString const description)
 {
-  return new BasicPluginRequirement(checker, description);
+  return std::make_shared<BasicPluginRequirement>(checker, description);
 }

--- a/src/pluginrequirements.h
+++ b/src/pluginrequirements.h
@@ -2,6 +2,7 @@
 #define PLUGINREQUIREMENTS_H
 
 #include <functional>
+#include <memory>
 #include <optional>
 
 #include <QStringList>
@@ -67,6 +68,7 @@ class PluginDependencyRequirement : public IPluginRequirement {
   friend class PluginRequirementFactory;
 
 public:
+  PluginDependencyRequirement(QStringList const& pluginNames);
 
   virtual std::optional<Problem> check(IOrganizer* organizer) const;
 
@@ -76,7 +78,6 @@ public:
   QStringList pluginNames() const { return m_PluginNames; }
 
 protected:
-  PluginDependencyRequirement(QStringList const& pluginNames);
   QString message() const;
   QStringList m_PluginNames;
 };
@@ -90,6 +91,7 @@ class GameDependencyRequirement : public IPluginRequirement {
   friend class PluginRequirementFactory;
 
 public:
+  GameDependencyRequirement(QStringList const& gameNames);
 
   virtual std::optional<Problem> check(IOrganizer* organizer) const;
 
@@ -99,7 +101,6 @@ public:
   QStringList gameNames() const { return m_GameNames; }
 
 protected:
-  GameDependencyRequirement(QStringList const& gameNames);
   QString message() const;
   QStringList m_GameNames;
 };
@@ -117,11 +118,11 @@ class DiagnoseRequirement : public IPluginRequirement {
   friend class PluginRequirementFactory;
 
 public:
+  DiagnoseRequirement(const IPluginDiagnose* diagnose);
 
   virtual std::optional<Problem> check(IOrganizer* organizer) const;
 
 private:
-  DiagnoseRequirement(const IPluginDiagnose* diagnose);
   const IPluginDiagnose* m_Diagnose;
 };
 
@@ -140,8 +141,8 @@ public:
    *
    * @param pluginNames Name of the plugin required.
    */
-  static IPluginRequirement* pluginDependency(QStringList const& pluginNames);
-  static IPluginRequirement* pluginDependency(QString const& pluginName) {
+  static std::shared_ptr<const IPluginRequirement> pluginDependency(QStringList const& pluginNames);
+  static std::shared_ptr<const IPluginRequirement> pluginDependency(QString const& pluginName) {
     return pluginDependency(QStringList{ pluginName });
   }
 
@@ -153,8 +154,8 @@ public:
    *
    * @note This differ from makePluginDependency only for the message.
    */
-  static IPluginRequirement* gameDependency(QStringList const& gameNames);
-  static IPluginRequirement* gameDependency(QString const& gameName) {
+  static std::shared_ptr<const IPluginRequirement> gameDependency(QStringList const& gameNames);
+  static std::shared_ptr<const IPluginRequirement> gameDependency(QString const& gameName) {
     return gameDependency(QStringList{ gameName });
   }
 
@@ -163,7 +164,7 @@ public:
    *
    * @param diagnose The diagnose plugin.
    */
-  static IPluginRequirement* diagnose(const IPluginDiagnose *diagnose);
+  static std::shared_ptr<const IPluginRequirement> diagnose(const IPluginDiagnose *diagnose);
 
   /**
    * @brief Create a generic requirement with the given checker and message.
@@ -172,7 +173,7 @@ public:
    *     return true if the requirement is met).
    * @param description The description to show user if the requirement is not met.
    */
-  static IPluginRequirement* basic(std::function<bool(IOrganizer*)> const& checker, QString const description);
+  static std::shared_ptr<const IPluginRequirement> basic(std::function<bool(IOrganizer*)> const& checker, QString const description);
 
 };
 


### PR DESCRIPTION
This is a proposition to improve the way save games are exposed to MO2. I will group here the information about the other repositories.

**Before this PR:**

- Game plugins expose a directory and a save file extension that MO2 then use to find all the saves (recursively for some time).
- It then use the `GameSaveInfo` feature to obtain a `ISaveGame` or a `ISaveGameWidget` to display, etc.

**After this PR:**

- Game plugins still expose the standard directory where saves are located.
- Game plugins are the one responsible for listing the saves, they can do whatever they want. They also return `ISaveGame` objects and not filenames.

There are two advantages for this:

- Game can list saves the way they want, so no more issues if saves are stored as folder, or in sub-folders, etc.
- Since the games return `ISaveGame`, we have access to a few extra information in the save list that we could use to display (currently not done, for a future PR).

One potential **drawback** is that the creation of `ISaveGame` can be expensive if done poorly. I added a timer to `refreshSaveList`, and with the current change, I did not notice slow down compared to the current version (tested with ~1000 saves, most of the time it's actually faster... ). 

## `uibase`

**Changes:**

- `IPluginGame::savegameExtension` and `IPluginGame::savegameSEExtension` are removed.
- `IPluginGame::listSaves` is added - This function takes a folder (`QDir`) and returns the saves in it. This returns `shared_ptr` for two reasons:
    - No need to bother about ownership in `modorganizer`, which could have been messy without this.
    - It's easy to expose with Boost.Python &mdash; `std::unique_ptr` is not, AFAIK, and `QSharedPointer` would require a bit more work.
- `ISaveGame` has received a lift:
    - `getFilename` > `getFilepath` &mdash; This is mostly for display currently. This could be a folder.
    - `getName` &mdash; This return a proper name for the save. Currently not used in MO2, but I did some testing to display it instead of the filename.
    - `hasScriptExtenderFile` removed.
- `ISaveGameInfoWidget::setSave` no takes a `ISaveGame` instead of a filename since we already have it.

---

## `game_features`

https://github.com/ModOrganizer2/modorganizer-game_features/pull/15

- `SaveGameInfo::getMissingAssets` now takes a `ISaveGame` instead of a filename, similar to `setSave` above.
- `SaveGameInfo::hasScriptExtenderSave` has been removed.

## `game_gamebryo`

https://github.com/modorganizer2/modorganizer-game_gamebryo/

- `GameGamebryo`:
    - Add `listSaves()` implementation which uses `savegameExtension()`.
    - `GameGamebryo::savegameExtension` is now private and implemented by the actual games (was already the case).
    - Added `GameGamebryo::makeSaveGame` to create save game.
 
- `GamebryoSaveGame`:
    - Clean `GamebryoSaveGame::FileMapper` &mdash; Methods now return objects instead of modifying the ones from the underlying `GamebryoSaveGame`.
    - Stored `GameGamebryo*` instead of `IPluginGame*` to access methods that are now only in `GameGamebryo`.
    - `GamebyroSaveGame::hasScriptExtenderFile()` is still present, but does not `override` anymore.
    - The "heavy" part of the save games (list of plugins, screenshot) are now "locked" under a `MemoizedLock` (that moved from `modorganizer` to `uibase`):
        - The basic information (PC name, location, level, etc.) have to fetch during construction.
        - The screenshot, plugins, etc., are only fetch when required.

## Game plugins using `game_gamebryo`

All the game plugins using `game_gamebryo` have been modified in the same way, so I will not cover all of them.

- Remove the game-specific `ISaveGameInfo`:
    - Those are not require anymore since there only purpose was to create actual `ISaveGame`, which is now done by `GameGamebryo::makeSaveGame`.
    - The Morrowind one is still present since it uses a different widget.

- The extraction from the save files is done in two parts:
    - A first part, considered "fast", during construction, that read basic information (see above).
    - A second part, considered "slow", only when required, that read plugins, screenshot, etc.
    - For Morrowind, the PC level is not read during construction since it's at the end of the file:
        - `getName()` will not include the PC level for Morrowind.

## Basic Games

Not much to see.
