### PR TITLE
Add method to get the type of IModInterface.

### DIFF
--- a/src/imodinterface.h
+++ b/src/imodinterface.h
@@ -182,6 +182,26 @@ public: // Meta-related information:
    */
   virtual std::shared_ptr<const MOBase::IFileTree> fileTree() const = 0;
 
+  /**
+   * @return true if this object represents the overwrite mod.
+   */
+  virtual bool isOverwrite() const = 0;
+
+  /**
+   * @return true if this object represents a backup.
+   */
+  virtual bool isBackup() const = 0;
+
+  /**
+   * @return true if this object represents a separator.
+   */
+  virtual bool isSeparator() const = 0;
+
+  /**
+   * @return true if this object represents a foreign mod.
+   */
+  virtual bool isForeign() const = 0;
+
 public: // Mutable operations:
 
   /**


### PR DESCRIPTION
Add a few methods to `IModInterface` to get the type of "mods".

This has been sitting locally for a while. It's not used right now but will probably be useful once context menus are available for plugins/extensions.