### PR TITLE
More stuff

### DIFF
--- a/src/filterwidget.h
+++ b/src/filterwidget.h
@@ -27,6 +27,7 @@ public:
 protected:
   bool filterAcceptsRow(int row, const QModelIndex& parent) const override;
   void sort(int column, Qt::SortOrder order = Qt::AscendingOrder) override;
+  bool lessThan(const QModelIndex& left, const QModelIndex& right) const override;
 
 private:
   FilterWidget& m_filter;
@@ -51,6 +52,8 @@ public:
   };
 
   using predFun = std::function<bool (const QRegularExpression& what)>;
+  using sortFun = std::function<bool (const QModelIndex&, const QModelIndex&)>;
+
 
   FilterWidget();
 
@@ -68,6 +71,9 @@ public:
 
   void setUseSourceSort(bool b);
   bool useSourceSort() const;
+
+  void setSortPredicate(sortFun f);
+  const sortFun& sortPredicate() const;
 
   void setFilterColumn(int i);
   int filterColumn() const;
@@ -108,6 +114,7 @@ private:
   bool m_useDelay;
   bool m_valid;
   bool m_useSourceSort;
+  sortFun m_lt;
   int m_filterColumn;
   bool m_filteringEnabled;
   bool m_filteredBorder;

--- a/src/utility.h
+++ b/src/utility.h
@@ -273,6 +273,11 @@ namespace shell
 
   QDLLEXPORT Result CreateDirectories(const QDir& dir);
   QDLLEXPORT Result DeleteDirectoryRecursive(const QDir& dir);
+
+  // sets the command used for Open() with a QUrl, %1 is replaced by the URL;
+  // pass an empty string to use the system handler
+  //
+  QDLLEXPORT void SetUrlHandler(const QString& cmd);
 }
 
 /**


### PR DESCRIPTION
- Added `FilterWidget::setSortPredicate()` as an easy way to get custom sorting without having to implement `sort()` on the source model.
- Added `SetUrlHandler()` for a custom URL handler and implemented that in `shell::Open()` for `QUrl`s.