### PR TITLE
Remove setName and remove from mod interface.

### DIFF
--- a/src/imodinterface.h
+++ b/src/imodinterface.h
@@ -262,29 +262,11 @@ public: // Mutable operations:
   virtual void setGameName(const QString &gameName) = 0;
 
   /**
-   * @brief set the name of this mod
-   *
-   * set the name of this mod. This will also update the name of the
-   * directory that contains this mod
-   *
-   * @param name new name of the mod
-   * @return true on success, false if the new name can't be used (i.e. because the new
-   *         directory name wouldn't be valid)
-   **/
-  virtual bool setName(const QString &name) = 0;
-
-  /**
    * @brief Set a URL for this mod.
    *
    * @param url The URL of this mod.
    */
   virtual void setUrl(const QString &url) = 0;
-
-  /**
-   * @brief delete the mod from the disc. This does not update the global ModInfo structure or indices
-   * @return true on success
-   */
-  virtual bool remove() = 0;
 
 public: // Plugin operations:
 

--- a/src/imodlist.h
+++ b/src/imodlist.h
@@ -103,6 +103,17 @@ public:
    */
   virtual bool removeMod(MOBase::IModInterface *mod) = 0;
 
+  /**
+   * @brief Rename the given mod.
+   *
+   * This invalidate the mod so you should use the returned value afterwards.
+   *
+   * @param mod The mod to rename.
+   *
+   * @return the new mod (after renaming) on success, a null pointer on error.
+   */
+  virtual MOBase::IModInterface* renameMod(MOBase::IModInterface *mod, const QString& name) = 0;
+
 
   /**
    * @brief retrieve the state of a mod
@@ -113,12 +124,12 @@ public:
 
   /**
    * @brief enable or disable a mod
-   * 
+   *
    * @param name name of the mod
    * @param active if true the mod is enabled, otherwise it's disabled
-   * 
+   *
    * @return true on success, false if the mod name is not valid
-   * 
+   *
    * @note calling this will cause MO to re-evaluate its virtual file system so this is fairly
    *       expensive
    */
@@ -126,12 +137,12 @@ public:
 
   /**
    * @brief enable or disable a list of mod
-   * 
+   *
    * @param names names of the mod
    * @param active if true mods are enabled, otherwise they are disabled
-   * 
+   *
    * @return the number of mods successfully enabled or disabled
-   * 
+   *
    * @note calling this will cause MO to re-evaluate its virtual file system so this is fairly
    *       expensive
    */


### PR DESCRIPTION
These methods should not be in the mod interface because they can actually affect the mod list. Currently these do not trigger refresh or anything so if plugins use them it's kind of weird.

The other `setXXX` methods do not affect the order or items in the mod list in the same way so those are fines.