### PR TITLE
Find parent for reportError()

### DIFF
--- a/src/report.cpp
+++ b/src/report.cpp
@@ -32,14 +32,46 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 namespace MOBase
 {
 
+QWidget* topLevelWindow()
+{
+  if (!qApp) {
+    return nullptr;
+  }
+
+  for (QWidget* w : qApp->topLevelWidgets()) {
+    if (dynamic_cast<QMainWindow*>(w)) {
+      return w;
+    }
+  }
+
+  return nullptr;
+}
+
+void criticalOnTop(const QString& message)
+{
+  QMessageBox mb(QMessageBox::Critical, QObject::tr("Mod Organizer"), message);
+
+  mb.show();
+  mb.activateWindow();
+  mb.raise();
+  mb.exec();
+}
+
 void reportError(const QString &message)
 {
   log::error("{}", message);
+
   if (QApplication::topLevelWidgets().count() != 0) {
-    QMessageBox messageBox(QMessageBox::Warning, QObject::tr("Error"), message, QMessageBox::Ok);
-    messageBox.exec();
+    if (auto* mw=topLevelWindow()) {
+      QMessageBox::warning(mw, QObject::tr("Error"), message, QMessageBox::Ok);
+    } else {
+      criticalOnTop(message);
+    }
   } else {
-    ::MessageBoxW(nullptr, message.toStdWString().c_str(), QObject::tr("Error").toStdWString().c_str(), MB_ICONERROR | MB_OK);
+    ::MessageBoxW(
+      0, message.toStdWString().c_str(),
+      QObject::tr("Error").toStdWString().c_str(),
+      MB_ICONERROR | MB_OK);
   }
 }
 

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -49,7 +49,7 @@ QWidget* topLevelWindow()
 
 void criticalOnTop(const QString& message)
 {
-  QMessageBox mb(QMessageBox::Critical, QObject::tr("Mod Organizer"), message);
+  QMessageBox mb(QMessageBox::Critical, "Mod Organizer", message);
 
   mb.show();
   mb.activateWindow();

--- a/src/report.h
+++ b/src/report.h
@@ -35,11 +35,18 @@ namespace MOBase {
 
 class ExpanderWidget;
 
-/**
- * Convenience function displaying an error message box. This function uses WinAPI if no Qt Window is available
- * yet or QMessageBox otherwise.
- */
+// Convenience function displaying an error message box. This function uses
+// WinAPI if no Qt Window is available yet or QMessageBox otherwise.
+//
 QDLLEXPORT void reportError(const QString &message);
+
+// shows a critical message box that's raised to the top of the zorder, useful
+// for messages without a main window, which sometimes makes them pop up behind
+// all other windows
+//
+// the dialog is not topmost, it's just raised once when shown
+//
+QDLLEXPORT void criticalOnTop(const QString& message);
 
 
 struct QDLLEXPORT TaskDialogButton


### PR DESCRIPTION
`reportError()` now tries to find the main window as its parent. If it's not found, it calls `criticalOnTop()` instead (moved from MO), which shows a message box on top of the z-order (but not top-most).

See https://github.com/ModOrganizer2/modorganizer/pull/1354.