### PR TITLE
formatNtMessage()

### DIFF
--- a/src/utility.h
+++ b/src/utility.h
@@ -487,7 +487,9 @@ bool isOneOf(const T &val, const std::initializer_list<T> &list) {
   return std::find(list.begin(), list.end(), val) != list.end();
 }
 
+
 QDLLEXPORT std::wstring formatSystemMessage(DWORD id);
+QDLLEXPORT std::wstring formatNtMessage(NTSTATUS s);
 
 inline std::wstring formatSystemMessage(HRESULT hr)
 {


### PR DESCRIPTION
- Added `formatNtMessage()` to get error messages for `NTSTATUS` errors, used in MO by `envfs` for the downloads and file register
- Refactored `formatSystemMessage()` into `getMessage()` and `formatMessage()` so they can be used for both system and NT errors