### PR TITLE
Remove boost dependency.

### DIFF
--- a/src/iplugindiagnose.h
+++ b/src/iplugindiagnose.h
@@ -27,27 +27,18 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <functional>
 #include <QObject>
 #include <QString>
-#pragma warning(push)
-#pragma warning(disable: 4100)
-#include <boost/signals2.hpp>
-#pragma warning(pop)
 
 namespace MOBase {
 
 
 /**
- * brief A plugin that creates problem reports to be displayed in the UI.
+ * @brief A plugin that creates problem reports to be displayed in the UI.
  * This can be used to report problems related to the same plugin (which implements further
  * interfaces) or as a stand-alone diagnosis tool.
  * This does not derive from IPlugin to prevent multiple inheritance issues. For stand-alone
  * diagnosis plugins, derive from IPlugin and IPluginDiagnose
  */
 class IPluginDiagnose {
-public:
-
-  /// signal to be emitted when the diagnosis information of the plugin is invalidated
-  typedef boost::signals2::signal<void (void)> SignalInvalidated;
-
 public:
 
   /**
@@ -87,11 +78,12 @@ public:
   virtual void startGuidedFix(unsigned int key) const = 0;
 
   /**
-   * @brief the application will use this to register callbacks to be called when
-   *        the diagnosis information needs to be re-evaluated
+   * @brief Register the callback to be called when this plugin is invalidated.
+   *
+   * Only one callback can be activate at a time.
    */
-  virtual boost::signals2::connection onInvalidated(std::function<void()> callback) {
-    return m_OnInvalidated.connect(callback);
+  void onInvalidated(std::function<void()> callback) {
+    m_OnInvalidated = callback;
   }
 
   virtual ~IPluginDiagnose() { }
@@ -104,7 +96,7 @@ protected:
 
 private:
 
-  SignalInvalidated m_OnInvalidated;
+  std::function<void()> m_OnInvalidated;
 
 };
 

--- a/src/iplugingame.h
+++ b/src/iplugingame.h
@@ -10,8 +10,7 @@ class QIcon;
 class QUrl;
 class QStringList;
 
-#include <boost/any.hpp>
-
+#include <any>
 #include <cstdint>
 #include <typeindex>
 #include <unordered_map>
@@ -81,8 +80,8 @@ public:
     auto iter = list.find(typeid(T));
     if (iter != list.end()) {
       try {
-        return boost::any_cast<T*>(iter->second);
-      } catch (const boost::bad_any_cast&) {
+        return std::any_cast<T*>(iter->second);
+      } catch (const std::bad_any_cast&) {
         // don't use log::error() here so log.h and fmt aren't pulled into
         // plugins
         qCritical(
@@ -317,7 +316,7 @@ public:
 
 protected:
 
-  virtual std::map<std::type_index, boost::any> featureList() const = 0;
+  virtual std::map<std::type_index, std::any> featureList() const = 0;
 
 };
 

--- a/src/pch.h
+++ b/src/pch.h
@@ -56,13 +56,6 @@
 #include <shobjidl.h>
 #include <Windows.h>
 
-// boost
-#include <boost/algorithm/string/trim.hpp>
-#include <boost/any.hpp>
-#include <boost/assign.hpp>
-#include <boost/scoped_array.hpp>
-#include <boost/signals2.hpp>
-
 // Qt
 #include <QAbstractButton>
 #include <QAction>


### PR DESCRIPTION
Remove `boost` dependency. This should make it easier to write C++ plugin without having to build the whole MO2 before... I'll probably try to set-up a CMake template project that does not require `mob` if people want to build C++ project.

I removed the signal in `IPluginDiagnose` because it was not really used... There was always a single callback, so I just store the `std::function<>()`.

Close https://github.com/ModOrganizer2/modorganizer/issues/862