### PR TITLE
Remove usage of fmtlib everywhere and boost in header.

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -7,8 +7,7 @@
 #include <QSize>
 #include <QRect>
 #include <QColor>
-#include <fmt/format.h>
-#include <boost/algorithm/string.hpp>
+#include <format>
 
 #include "dllimport.h"
 
@@ -43,7 +42,7 @@ namespace MOBase::log::details
 // those are kept in this namespace so they don't leak all over the place;
 // they're used directly by doLog() below
 
-template <class T>
+template <class T, class = void>
 struct converter
 {
   static const T& convert(const T& t)
@@ -101,9 +100,19 @@ struct QDLLEXPORT converter<QVariant>
   static std::string convert(const QVariant& v);
 };
 
+// std::format has issues with enum (maybe it's standard?), so we need a
+// custom converter for all Qt enums
+template <class Enum>
+struct QDLLEXPORT converter<Enum, std::enable_if_t<std::is_enum_v<Enum>>> {
+  static auto convert(const Enum& e) {
+    return static_cast<std::underlying_type_t<Enum>>(e);
+  }
+};
 
 void QDLLEXPORT doLogImpl(
   spdlog::logger& lg, Levels lv, const std::string& s) noexcept;
+
+void QDLLEXPORT ireplace_all(std::string& input, std::string const& search, std::string const& replace) noexcept;
 
 template <class F, class... Args>
 void doLog(
@@ -115,18 +124,18 @@ void doLog(
 
   try
   {
-    s = fmt::format(
+    s = std::format(
       std::forward<F>(format),
       converter<std::decay_t<Args>>::convert(std::forward<Args>(args))...);
 
     // check the blacklist
     for (const BlacklistEntry& entry : bl) {
-      boost::algorithm::ireplace_all(s, entry.filter, entry.replacement);
+      ireplace_all(s, entry.filter, entry.replacement);
     }
   }
-  catch(fmt::format_error&)
+  catch(std::format_error&)
   {
-    s = "format error while logging"; 
+    s = "format error while logging";
     lv = Levels::Error;
   }
   catch(std::exception&)

--- a/src/pch.h
+++ b/src/pch.h
@@ -17,6 +17,7 @@
 
 #pragma warning(push, 3)
 #pragma warning(disable: 4365)  // signed/unsigned mismatch
+#pragma warning(disable: 4668)  // preprocessor macro used but not defined
 #pragma warning(disable: 4774)  // bad format string
 #pragma warning(disable: 4946)  // reinterpret_cast used between related classes
 #pragma warning(disable: 4800)  // implicit conversion
@@ -42,9 +43,6 @@
 #include <vector>
 #include <wchar.h>
 #include <cwctype>
-
-// fmt
-#include <fmt/format.h>
 
 // windows
 #ifndef NOMINMAX

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -23,6 +23,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include "report.h"
 #include "log.h"
 #include <memory>
+#include <format>
 #include <sstream>
 #include <QDir>
 #include <QBuffer>
@@ -939,7 +940,7 @@ QString getProductVersion(QString const& filepath) {
   }
 
   WORD* lpw = (WORD*)lpb;
-  auto query = fmt::format(L"\\StringFileInfo\\{:04x}{:04x}\\ProductVersion", lpw[0], lpw[1]);
+  auto query = std::format(L"\\StringFileInfo\\{:04x}{:04x}\\ProductVersion", lpw[0], lpw[1]);
   if (!::VerQueryValueW(buff.data(), query.data(), (void**)&lpb, &uiSize) && uiSize > 0) {
     log::debug("VerQueryValue Error %d", ::GetLastError());
     return "";


### PR DESCRIPTION
- Remove usage of fmtlib for the standard `<format>` since it's available in VS now.
- Some fixes for spdlog v1.10.0 and switch spdlog to `std::format` via `SPDLOG_USE_STD_FORMAT`.
- Remove the boost include in `log.h` to avoid exposing boost.
  - I completely removed boost from uibase a few commits ago but it got re-added for the blacklist stuff in the logs. Currently it's only some `algorithm/string.h` function, maybe it would be a good idea to completely get rid of it (again...) in `uibase`.