### PR TITLE
Match backslash in fixDirectoryName QRegularExpression

### DIFF
--- a/src/filesystemutilities.cpp
+++ b/src/filesystemutilities.cpp
@@ -12,7 +12,7 @@ bool fixDirectoryName(QString& name)
   while (temp.endsWith('.'))
     temp.chop(1);
 
-  temp.replace(QRegularExpression("[<>:\"/\\|?*]"), "");
+  temp.replace(QRegularExpression("[<>:\"/\\\\|?*]"), "");
   static QString invalidNames[] = {"CON",  "PRN",  "AUX",  "NUL",  "COM1", "COM2",
                                    "COM3", "COM4", "COM5", "COM6", "COM7", "COM8",
                                    "COM9", "LPT1", "LPT2", "LPT3", "LPT4", "LPT5",


### PR DESCRIPTION
This fixes an issue where backslashes were not removed when creating a mod or separator. The issue could cause problems such as directories with trailing spaces or creating the meta file in a subdirectory instead of the root of a mod.