### PR TITLE
Add `displayGameName()` and `lootGameName()` to plugin-base

### DIFF
--- a/src/iplugingame.h
+++ b/src/iplugingame.h
@@ -81,6 +81,16 @@ public:
    */
   virtual QString gameName() const = 0;
 
+  /**
+   * used to override display-specific text in place of the gameName
+   * for example the text for the main window or the initial instance creation game plugin selection/list
+   * 
+   * added for future translation purposes or to make plugins visually more accurate in the ui
+   * 
+   * @return display-specific name of the game
+   */
+  virtual QString displayGameName() const { return gameName(); }
+
   template <typename T>
   T* feature() const
   {
@@ -256,6 +266,14 @@ public:
    * nexus mod pages as far as I can see.
    */
   virtual QString gameShortName() const = 0;
+
+  /**
+   * @brief game name that's passed to the LOOT cli --game argument
+   * 
+   * only applicable for games using LOOT based sorting
+   * defaults to gameShortName()
+   */
+  virtual QString lootGameName() const { return gameShortName(); }
 
   /**
    * @brief Get any primary alternative 'short' name for the game

--- a/src/iplugingame.h
+++ b/src/iplugingame.h
@@ -83,10 +83,12 @@ public:
 
   /**
    * used to override display-specific text in place of the gameName
-   * for example the text for the main window or the initial instance creation game plugin selection/list
-   * 
-   * added for future translation purposes or to make plugins visually more accurate in the ui
-   * 
+   * for example the text for the main window or the initial instance creation game
+   * plugin selection/list
+   *
+   * added for future translation purposes or to make plugins visually more accurate in
+   * the ui
+   *
    * @return display-specific name of the game
    */
   virtual QString displayGameName() const { return gameName(); }
@@ -269,7 +271,7 @@ public:
 
   /**
    * @brief game name that's passed to the LOOT cli --game argument
-   * 
+   *
    * only applicable for games using LOOT based sorting
    * defaults to gameShortName()
    */


### PR DESCRIPTION
# Modifications
- Add `lootGameName()` which will give the plugin a tad bit more control over LOOT cli args
- Add `displayGameName()` which will be used to separate display-specific calls & more integral calls to `gameName()`, will also pave way for deeper plugin localization

# Notes
Changes are planned to other pieces of MO in different repositories that will use these additions