### PR TITLE
Switch from fmtlib to std::format.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Build UI Base
         uses: ModOrganizer2/build-with-mob-action@master
         with:
-          mo2-third-parties: fmt gtest spdlog boost
+          mo2-third-parties: gtest spdlog boost
           mo2-dependencies: cmake_common

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ mo2_configure_uibase(uibase
 	WARNINGS ON
 	EXTERNAL_WARNINGS ON
 	TRANSLATIONS OFF
-	PUBLIC_DEPENDS fmt Qt::Widgets Qt::Network Qt::QuickWidgets
+	PUBLIC_DEPENDS Qt::Widgets Qt::Network Qt::QuickWidgets
 	PRIVATE_DEPENDS boost boost::thread Qt::Qml Qt::Quick spdlog)
 target_compile_definitions(uibase PRIVATE -DUIBASE_EXPORT)
 mo2_install_target(uibase)

--- a/src/formatters.h
+++ b/src/formatters.h
@@ -1,0 +1,177 @@
+#pragma once
+
+#include <QColor>
+#include <QFlag>
+#include <QFlags>
+#include <QRect>
+#include <QSize>
+#include <QString>
+#include <QVariant>
+
+namespace MOBase::details
+{
+template <class CharT>
+inline std::basic_string<CharT> toStdBasicString(QString const& qstring);
+
+template <>
+inline std::basic_string<char> toStdBasicString(QString const& qstring)
+{
+  return qstring.toStdString();
+}
+template <>
+inline std::basic_string<wchar_t> toStdBasicString(QString const& qstring)
+{
+  return qstring.toStdWString();
+}
+template <>
+inline std::basic_string<char16_t> toStdBasicString(QString const& qstring)
+{
+  return qstring.toStdU16String();
+}
+template <>
+inline std::basic_string<char32_t> toStdBasicString(QString const& qstring)
+{
+  return qstring.toStdU32String();
+}
+
+inline QString fromStdBasicString(std::string const& value)
+{
+  return QString::fromStdString(value);
+}
+inline QString fromStdBasicString(std::wstring const& value)
+{
+  return QString::fromStdWString(value);
+}
+inline QString fromStdBasicString(std::u16string const& value)
+{
+  return QString::fromStdU16String(value);
+}
+inline QString fromStdBasicString(std::u32string const& value)
+{
+  return QString::fromStdU32String(value);
+}
+}  // namespace MOBase::details
+
+template <class CharT>
+struct std::formatter<QString, CharT> : std::formatter<std::basic_string<CharT>, CharT>
+{
+  template <class FmtContext>
+  FmtContext::iterator format(QString s, FmtContext& ctx) const
+  {
+    return std::formatter<std::basic_string<CharT>, CharT>::format(
+        MOBase::details::toStdBasicString<CharT>(s), ctx);
+  }
+};
+
+template <class CharT1, class CharT2>
+  requires(!std::is_same_v<CharT1, CharT2>)
+struct std::formatter<std::basic_string<CharT1>, CharT2>
+    : std::formatter<std::basic_string<CharT2>, CharT2>
+{
+  template <class FmtContext>
+  FmtContext::iterator format(std::basic_string<CharT1> s, FmtContext& ctx) const
+  {
+    return std::formatter<std::basic_string<CharT2>, CharT2>::format(
+        MOBase::details::toStdBasicString<CharT2>(
+            MOBase::details::fromStdBasicString(s)),
+        ctx);
+  }
+};
+
+template <class CharT>
+struct std::formatter<QStringView, CharT> : std::formatter<QString, CharT>
+{
+  template <class FmtContext>
+  FmtContext::iterator format(QStringView s, FmtContext& ctx) const
+  {
+    return std::formatter<QString, CharT>::format(s.toString(), ctx);
+  }
+};
+
+template <class CharT>
+struct std::formatter<QSize, CharT> : std::formatter<std::basic_string<CharT>, CharT>
+{
+  template <class FmtContext>
+  FmtContext::iterator format(QSize s, FmtContext& ctx) const
+  {
+    return std::format_to(ctx.out(), "QSize({}, {})", s.width(), s.height());
+  }
+};
+
+template <class CharT>
+struct std::formatter<QRect, CharT> : std::formatter<std::basic_string<CharT>, CharT>
+{
+  template <class FmtContext>
+  FmtContext::iterator format(QRect r, FmtContext& ctx) const
+  {
+    return std::format_to(ctx.out(), "QRect({},{}-{},{})", r.left(), r.top(), r.right(),
+                          r.bottom());
+  }
+};
+
+template <class CharT>
+struct std::formatter<QColor, CharT> : std::formatter<std::basic_string<CharT>, CharT>
+{
+  template <class FmtContext>
+  FmtContext::iterator format(QColor c, FmtContext& ctx) const
+  {
+    return std::format_to(ctx.out(), "QColor({}, {}, {}, {})", c.red(), c.green(),
+                          c.blue(), c.alpha());
+  }
+};
+
+template <class CharT>
+struct std::formatter<QByteArray, CharT>
+    : std::formatter<std::basic_string<CharT>, CharT>
+{
+  template <class FmtContext>
+  FmtContext::iterator format(QByteArray v, FmtContext& ctx) const
+  {
+    return std::format_to(ctx.out(), "QByteArray({} bytes)", v.size());
+  }
+};
+
+template <class CharT>
+struct std::formatter<QVariant, CharT> : std::formatter<std::basic_string<CharT>, CharT>
+{
+  template <class FmtContext>
+  FmtContext::iterator format(QVariant v, FmtContext& ctx) const
+  {
+    return std::format_to(
+        ctx.out(), "QVariant(type={}, value={})", v.typeName(),
+        (v.typeId() == QMetaType::Type::QByteArray ? "(binary)" : v.toString()));
+  }
+};
+
+template <class CharT>
+struct std::formatter<QFlag, CharT> : std::formatter<int, CharT>
+{
+  template <class FmtContext>
+  FmtContext::iterator format(QFlag v, FmtContext& ctx) const
+  {
+    return std::formatter<int, CharT>::format(static_cast<int>(v), ctx);
+  }
+};
+
+template <class T, class CharT>
+struct std::formatter<QFlags<T>, CharT> : std::formatter<int, CharT>
+{
+  template <class FmtContext>
+  FmtContext::iterator format(QFlags<T> v, FmtContext& ctx) const
+  {
+    // TODO: display flags has aa | bb | cc?
+    return std::formatter<int, CharT>::format(v.toInt(), ctx);
+  }
+};
+
+template <class Enum, class CharT>
+  requires std::is_enum_v<Enum>
+struct std::formatter<Enum, CharT> : std::formatter<std::underlying_type_t<Enum>, CharT>
+{
+  template <class FmtContext>
+  FmtContext::iterator format(Enum v, FmtContext& ctx) const
+  {
+    return std::formatter<std::underlying_type_t<Enum>, CharT>::format(
+        static_cast<std::underlying_type_t<Enum>>(v), ctx);
+  }
+};

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -237,7 +237,7 @@ void Logger::setFile(const File& f)
         addSink(m_file);
       }
     } catch (spdlog::spdlog_ex& e) {
-      error(e.what());
+      error("{}", e.what());
     }
   }
 }
@@ -368,49 +368,6 @@ Logger& getDefault()
 
 namespace MOBase::log::details
 {
-
-std::string converter<std::wstring>::convert(const std::wstring& s)
-{
-  return QString::fromStdWString(s).toStdString();
-}
-
-std::string converter<QString>::convert(const QString& s)
-{
-  return s.toStdString();
-}
-
-std::string converter<QStringView>::convert(const QStringView& s)
-{
-  return converter<QString>::convert(s.toString());
-}
-
-std::string converter<QSize>::convert(const QSize& s)
-{
-  return fmt::format("QSize({}, {})", s.width(), s.height());
-}
-
-std::string converter<QRect>::convert(const QRect& r)
-{
-  return fmt::format("QRect({},{}-{},{})", r.left(), r.top(), r.right(), r.bottom());
-}
-
-std::string converter<QColor>::convert(const QColor& c)
-{
-  return fmt::format("QColor({}, {}, {}, {})", c.red(), c.green(), c.blue(), c.alpha());
-}
-
-std::string converter<QByteArray>::convert(const QByteArray& v)
-{
-  return fmt::format("QByteArray({} bytes)", v.size());
-}
-
-std::string converter<QVariant>::convert(const QVariant& v)
-{
-  return fmt::format("QVariant(type={}, value='{}')", v.typeName(),
-                     (v.typeId() == QMetaType::Type::QByteArray
-                          ? "(binary)"
-                          : v.toString().toStdString()));
-}
 
 void doLogImpl(spdlog::logger& lg, Levels lv, const std::string& s) noexcept
 {

--- a/src/report.cpp
+++ b/src/report.cpp
@@ -383,8 +383,9 @@ QPixmap TaskDialog::standardIcon(QMessageBox::Icon icon) const
     break;
   case QMessageBox::Question:
     i = s->standardIcon(QStyle::SP_MessageBoxQuestion, 0, m_dialog.get());
-
-  case QMessageBox::NoIcon:  // fall-through
+    break;
+  case QMessageBox::NoIcon:
+    [[fallthrough]];
   default:
     break;
   }

--- a/src/utility.cpp
+++ b/src/utility.cpp
@@ -34,6 +34,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <sstream>
 #define WIN32_LEAN_AND_MEAN
 #include <Windows.h>
+#include <format>
 
 #define FO_RECYCLE 0x1003
 
@@ -715,15 +716,7 @@ bool copyFileRecursive(const QString& source, const QString& baseDir,
 
 std::wstring ToWString(const QString& source)
 {
-  // FIXME
-  // why not source.toStdWString() ?
-  wchar_t* buffer = new wchar_t[static_cast<std::size_t>(source.count()) + 1];
-  source.toWCharArray(buffer);
-  buffer[source.count()] = L'\0';
-  std::wstring result(buffer);
-  delete[] buffer;
-
-  return result;
+  return source.toStdWString();
 }
 
 std::string ToString(const QString& source, bool utf8)
@@ -986,7 +979,7 @@ QString getProductVersion(QString const& filepath)
 
   WORD* lpw = (WORD*)lpb;
   auto query =
-      fmt::format(L"\\StringFileInfo\\{:04x}{:04x}\\ProductVersion", lpw[0], lpw[1]);
+      std::format(L"\\StringFileInfo\\{:04x}{:04x}\\ProductVersion", lpw[0], lpw[1]);
   if (!::VerQueryValueW(buff.data(), query.data(), (void**)&lpb, &uiSize) &&
       uiSize > 0) {
     log::debug("VerQueryValue Error %d", ::GetLastError());


### PR DESCRIPTION
Switch from `fmtlib` to `std::format`.

I already updated the modorganizer project to follow these changes, PR to come, but other repositories probably needs to be updated as well.

Some details:

- I removed the custom converters in favor of specialization of `std::formatter` - There is a specialization to allow using `std::basic_string` of any char-type with any format string (e.g., `std::format("{}", L"Hello World!"`). This was done to follow the previous converter behavior, not sure if we want to keep it.
- I added overloads for all logs function that takes `std::format_string` - This allows for compile-time checking of the format string. In an ideal world, that would be the sole overload, but we have many places with translated format string. I kept the templated `F` version, but this could probably be replaced with a `QStringView`/`QString` overload.


---

**Note:** This supersedes https://github.com/ModOrganizer2/modorganizer-uibase/pull/142