### PR TITLE
Add author and description methods to `IPluginList`

### DIFF
--- a/src/ipluginlist.h
+++ b/src/ipluginlist.h
@@ -220,6 +220,21 @@ public:
    * exist.
    */
   virtual bool hasNoRecords(const QString& name) const = 0;
+
+  /**
+   * @brief retrieve the author of a plugin
+   * @param name filename of the plugin (without path but with file extension)
+   * @return the author of the plugin or an empty string if the plugin doesn't exist
+   */
+  virtual QString author(const QString& name) const = 0;
+
+  /**
+   * @brief retrieve the description of a plugin
+   * @param name filename of the plugin (without path but with file extension)
+   * @return the description of the plugin or an empty string if the plugin doesn't
+   * exist
+   */
+  virtual QString description(const QString& name) const = 0;
 };
 
 }  // namespace MOBase


### PR DESCRIPTION
This PR adds `author` and `description` methods to `IPluginList` for use in Python plugins. I will also open PRs on the main- and Python plugin repositories to add the implementations.

For my [LOOT Warning Checker plugin](https://github.com/JonathanFeenstra/modorganizer-loot-warning-checker), the `description` method would be especially useful, since it allows me to find the version of a plugin without having to parse the SNAM-subrecord again.