### PR TITLE
Oblivion Remastered Support

### DIFF
--- a/src/formatters/random_access_containers.h
+++ b/src/formatters/random_access_containers.h
@@ -9,12 +9,8 @@ namespace MOBase::details
 {
 template <typename Container>
 concept random_access_container = requires(Container const& c) {
-  {
-    c.begin()
-  } -> std::random_access_iterator;
-  {
-    c.end()
-  } -> std::random_access_iterator;
+  { c.begin() } -> std::random_access_iterator;
+  { c.end() } -> std::random_access_iterator;
 };
 }  // namespace MOBase::details
 

--- a/src/iplugingame.h
+++ b/src/iplugingame.h
@@ -163,6 +163,8 @@ public:
    */
   virtual QDir dataDirectory() const = 0;
 
+  virtual QString modDataDirectory() const { return ""; }
+
   /**
    * this function may be called before init()
    *
@@ -349,6 +351,23 @@ public:
    * @brief Get a URL for the support page for the game
    */
   virtual QString getSupportURL() const { return ""; }
+
+  /**
+   * @brief Gets a virtualization mapping for mod directories
+   * 
+   * @note Maps internal mod directories to a list of paths
+   * @default Root directory maps to game data path(s)
+   */
+  virtual QMap<QString, QStringList> getModMappings() const
+  {
+    QMap<QString, QStringList> map;
+    QStringList dataDirs = {dataDirectory().absolutePath()};
+    for (auto path : secondaryDataDirectories()) {
+      dataDirs.append(path.absolutePath());
+    }
+    map[""] = dataDirs;
+    return map;
+  }
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(IPluginGame::ProfileSettings)

--- a/src/iplugingame.h
+++ b/src/iplugingame.h
@@ -354,7 +354,7 @@ public:
 
   /**
    * @brief Gets a virtualization mapping for mod directories
-   * 
+   *
    * @note Maps internal mod directories to a list of paths
    * @default Root directory maps to game data path(s)
    */

--- a/src/version.rc
+++ b/src/version.rc
@@ -3,8 +3,8 @@
 // If VS_FF_PRERELEASE is not set, MO labels the build as a release and uses VER_FILEVERSION to determine version number.
 // Otherwise, if letters are used in VER_FILEVERSION_STR, uses the full MOBase::VersionInfo parser
 // Otherwise, uses the numbers from VER_FILEVERSION and sets the release type as pre-alpha
-#define VER_FILEVERSION     2,5.2
-#define VER_FILEVERSION_STR "2.5.2\0"
+#define VER_FILEVERSION     2.5.3
+#define VER_FILEVERSION_STR "2.5.3\0"
 
 VS_VERSION_INFO VERSIONINFO
 FILEVERSION     VER_FILEVERSION
@@ -24,7 +24,7 @@ BEGIN
         VALUE "FileDescription",  "MO2 Base UI plugin API library\0"
         VALUE "OriginalFilename", "uibase.dll\0"
         VALUE "InternalName", "uibase\0"
-        VALUE "LegalCopyright", "Copyright 2011-2016 Sebastian Herbord\r\nCopyright 2016-2023 Mod Organizer 2 contributors\0"
+        VALUE "LegalCopyright", "Copyright 2011-2016 Sebastian Herbord\r\nCopyright 2016-2025 Mod Organizer 2 contributors\0"
         VALUE "ProductName",      "Mod Organizer 2 UI Base\0"
         VALUE "ProductVersion", VER_FILEVERSION_STR
       END


### PR DESCRIPTION
Adding interfaces for VFS mod mapping updates (used to get Oblivion Remastered to map to multiple locations).

* modDataDirectory defines mod directory that maps to 'Data'
  - This is used to tell the main interface where to look for 'Data' files and defaults to the root directory
* getModMappings allows mapping directories to multiple locations
  - This contains mod subdirectory -> VFS directory mappings (where the VFS mappings can be a list of locations)
  - By default, will map the root mod directory to the game 'data' directory (and any secondary data directories if defined)
  - Oblivion Releloaded maps 'Data' to the game `Data`, 'Paks' to the game `Paks\~mods`, 'OBSE' to the root `OBSE` directory and so on.