### PR TITLE
Avoid repeated QRegularExpression compilation

### DIFF
--- a/src/versioninfo.cpp
+++ b/src/versioninfo.cpp
@@ -22,6 +22,11 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 #include <QRegularExpression>
 #include <QVersionNumber>
 
+namespace
+{
+const QRegularExpression VERSION_REGEX("^(\\d+)(\\.(\\d+))?(\\.(\\d+))?(\\.(\\d+))?");
+}
+
 namespace MOBase
 {
 
@@ -289,8 +294,7 @@ void VersionInfo::parse(const QString& versionString, VersionScheme scheme,
     temp.remove(0, 1);
   }
 
-  QRegularExpression exp("^(\\d+)(\\.(\\d+))?(\\.(\\d+))?(\\.(\\d+))?");
-  auto match = exp.match(temp);
+  auto match = VERSION_REGEX.match(temp);
   if (match.hasMatch()) {
     m_Major             = match.captured(1).toInt();
     m_Minor             = match.captured(3).toInt();
@@ -310,7 +314,7 @@ void VersionInfo::parse(const QString& versionString, VersionScheme scheme,
       m_Scheme           = SCHEME_DECIMALMARK;
       m_DecimalPositions = (int)match.captured(3).size();
     }
-    temp.remove(exp);
+    temp.remove(VERSION_REGEX);
   } else {
     m_Scheme = SCHEME_LITERAL;
   }


### PR DESCRIPTION
Frequent recompilation of this expression accounts for ~30% of time spent in `DownloadManager::refreshList` for a list of about 4200 downloads.

A similarly significant amount of time is spent on synchronization of QSettings in `DownloadManager::DownloadInfo::createFromMeta`. We can disable this synchronization with `QSettings::setAtomicSyncRequired`, but I am unsure if it is safe to do so.