### PR TITLE
Add generic GameArchiveHandler game feature for non-Bethesda archive support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,8 @@ CMakeLists.txt.user
 /src/uibasetests_en.ts
 /install
 /tests/cmake/build
+/_deploy
+/build-local
+/_tmp_uibase_build.log
+/_deploy*
+/vsbuild*

--- a/build_uibase_only.bat
+++ b/build_uibase_only.bat
@@ -1,0 +1,13 @@
+@echo off
+setlocal
+call "C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\Common7\Tools\VsDevCmd.bat" -arch=amd64
+if errorlevel 1 exit /b %errorlevel%
+cd /d D:\Projects\modorganizer-uibase-game-archive-handler
+cmake -S . -B build-local -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_CXX_FLAGS="/EHsc /MP /W4" -DVCPKG_TARGET_TRIPLET=x64-windows-static-md -DVCPKG_MANIFEST_NO_DEFAULT_FEATURES=ON -DVCPKG_MANIFEST_FEATURES=testing -DCMAKE_TOOLCHAIN_FILE="%VCPKG_ROOT%\scripts\buildsystems\vcpkg.cmake"
+if errorlevel 1 exit /b %errorlevel%
+cmake --build build-local -j 8
+if errorlevel 1 exit /b %errorlevel%
+cmake --install build-local
+if errorlevel 1 exit /b %errorlevel%
+echo UIBASE_ONLY_BUILD_DONE
+exit /b 0

--- a/include/uibase/game_features/gamearchivehandler.h
+++ b/include/uibase/game_features/gamearchivehandler.h
@@ -1,0 +1,68 @@
+#ifndef UIBASE_GAMEFEATURES_GAMEARCHIVEHANDLER_H
+#define UIBASE_GAMEFEATURES_GAMEARCHIVEHANDLER_H
+
+#include <functional>
+
+#include <QString>
+#include <QStringList>
+#include <QtGlobal>
+
+#include "./game_feature.h"
+
+namespace MOBase
+{
+
+/**
+ * @brief Generic archive handler for game-specific archive formats.
+ *
+ * This feature exists so tools can delegate archive handling to the active game plugin
+ * when the archive format is game-specific. Bethesda archives remain handled through
+ * bsatk; non-Bethesda archive ownership belongs in game plugins rather than in uibase
+ * or bsatk.
+ */
+class GameArchiveHandler : public details::GameFeatureCRTP<GameArchiveHandler>
+{
+public:
+  using ProgressCallback = std::function<void(qint64 current, qint64 total)>;
+
+  /**
+   * @brief File dialog name filters for archives this handler can process.
+   */
+  virtual QStringList supportedArchiveNameFilters() const { return {}; }
+
+  /**
+   * @brief Check whether this handler can process the archive at the given path.
+   */
+  virtual bool supportsArchive(const QString& archivePath) const = 0;
+
+  /**
+   * @brief Extract an archive into the given output directory.
+   *
+   * @return true on success, false on failure or cancellation.
+   */
+  virtual bool extractArchive(const QString& archivePath, const QString& outputDirectory,
+                              const ProgressCallback& progress = {},
+                              QString* errorMessage             = nullptr) const = 0;
+
+  /**
+   * @brief Check whether this handler can create the given archive.
+   */
+  virtual bool canCreateArchive(const QString&) const { return false; }
+
+  /**
+   * @brief Create an archive from the given source directory.
+   *
+   * @return true on success, false if archive creation is unsupported, fails, or is
+   * cancelled.
+   */
+  virtual bool createArchive(const QString&, const QString&,
+                             const ProgressCallback& = {},
+                             QString*                = nullptr) const
+  {
+    return false;
+  }
+};
+
+}  // namespace MOBase
+
+#endif

--- a/include/uibase/game_features/gamearchivehandler.h
+++ b/include/uibase/game_features/gamearchivehandler.h
@@ -35,9 +35,10 @@ public:
    *
    * @return true on success, false on failure or cancellation.
    */
-  virtual bool extractArchive(const QString& archivePath, const QString& outputDirectory,
+  virtual bool extractArchive(const QString& archivePath,
+                              const QString& outputDirectory,
                               const ProgressCallback& progress = {},
-                              QString* errorMessage             = nullptr) const = 0;
+                              QString* errorMessage            = nullptr) const = 0;
 
   /**
    * @brief File dialog name filters for archives this handler can process.
@@ -59,8 +60,7 @@ public:
    * cancelled.
    */
   virtual bool createArchive(const QString&, const QString&,
-                             const ProgressCallback& = {},
-                             QString*                = nullptr) const
+                             const ProgressCallback& = {}, QString* = nullptr) const
   {
     return false;
   }

--- a/include/uibase/game_features/gamearchivehandler.h
+++ b/include/uibase/game_features/gamearchivehandler.h
@@ -26,11 +26,6 @@ public:
   using ProgressCallback = std::function<void(qint64 current, qint64 total)>;
 
   /**
-   * @brief File dialog name filters for archives this handler can process.
-   */
-  virtual QStringList supportedArchiveNameFilters() const { return {}; }
-
-  /**
    * @brief Check whether this handler can process the archive at the given path.
    */
   virtual bool supportsArchive(const QString& archivePath) const = 0;
@@ -43,6 +38,14 @@ public:
   virtual bool extractArchive(const QString& archivePath, const QString& outputDirectory,
                               const ProgressCallback& progress = {},
                               QString* errorMessage             = nullptr) const = 0;
+
+  /**
+   * @brief File dialog name filters for archives this handler can process.
+   *
+   * NOTE: Kept after legacy virtuals to preserve ABI slot order for
+   * supportsArchive()/extractArchive() with pre-existing MO2 binaries.
+   */
+  virtual QStringList supportedArchiveNameFilters() const { return {}; }
 
   /**
    * @brief Check whether this handler can create the given archive.

--- a/include/uibase/game_features/igamefeatures.h
+++ b/include/uibase/game_features/igamefeatures.h
@@ -16,6 +16,7 @@ class IPluginGame;
 // top-level game features
 class BSAInvalidation;
 class DataArchives;
+class GameArchiveHandler;
 class GamePlugins;
 class LocalSavegames;
 class ModDataChecker;
@@ -29,9 +30,9 @@ namespace details
 
   // use pointers in the tuple since are only forward-declaring the features here
   using BaseGameFeaturesP =
-      std::tuple<BSAInvalidation*, DataArchives*, GamePlugins*, LocalSavegames*,
-                 ModDataChecker*, ModDataContent*, SaveGameInfo*, ScriptExtender*,
-                 UnmanagedMods*>;
+      std::tuple<BSAInvalidation*, DataArchives*, GameArchiveHandler*, GamePlugins*,
+                 LocalSavegames*, ModDataChecker*, ModDataContent*, SaveGameInfo*,
+                 ScriptExtender*, UnmanagedMods*>;
 
 }  // namespace details
 

--- a/include/uibase/game_features/igamefeatures.h
+++ b/include/uibase/game_features/igamefeatures.h
@@ -31,8 +31,8 @@ namespace details
   // use pointers in the tuple since are only forward-declaring the features here
   using BaseGameFeaturesP =
       std::tuple<BSAInvalidation*, DataArchives*, GamePlugins*, LocalSavegames*,
-           ModDataChecker*, ModDataContent*, SaveGameInfo*, ScriptExtender*,
-           UnmanagedMods*>;
+                 ModDataChecker*, ModDataContent*, SaveGameInfo*, ScriptExtender*,
+                 UnmanagedMods*>;
 
 }  // namespace details
 

--- a/include/uibase/game_features/igamefeatures.h
+++ b/include/uibase/game_features/igamefeatures.h
@@ -30,9 +30,9 @@ namespace details
 
   // use pointers in the tuple since are only forward-declaring the features here
   using BaseGameFeaturesP =
-      std::tuple<BSAInvalidation*, DataArchives*, GameArchiveHandler*, GamePlugins*,
-                 LocalSavegames*, ModDataChecker*, ModDataContent*, SaveGameInfo*,
-                 ScriptExtender*, UnmanagedMods*>;
+      std::tuple<BSAInvalidation*, DataArchives*, GamePlugins*, LocalSavegames*,
+           ModDataChecker*, ModDataContent*, SaveGameInfo*, ScriptExtender*,
+           UnmanagedMods*>;
 
 }  // namespace details
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,6 +101,7 @@ set(formatters_header
 )
 
 add_library(uibase SHARED)
+set_target_properties(uibase PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
 mo2_configure_target(uibase NO_SOURCES WARNINGS ON EXTERNAL_WARNINGS ON)
 mo2_default_source_group()
 target_compile_features(uibase PUBLIC cxx_std_23)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -83,6 +83,7 @@ set(game_features_header
 	../include/uibase/game_features/bsainvalidation.h
 	../include/uibase/game_features/dataarchives.h
 	../include/uibase/game_features/game_feature.h
+	../include/uibase/game_features/gamearchivehandler.h
 	../include/uibase/game_features/gameplugins.h
 	../include/uibase/game_features/igamefeatures.h
 	../include/uibase/game_features/localsavegames.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,7 @@ set(formatters_header
 add_library(uibase SHARED)
 mo2_configure_target(uibase NO_SOURCES WARNINGS ON EXTERNAL_WARNINGS ON)
 mo2_default_source_group()
+target_compile_features(uibase PUBLIC cxx_std_23)
 
 mo2_target_sources(uibase
 	FOLDER src


### PR DESCRIPTION
This PR adds a generic GameArchiveHandler game feature to modorganizer-uibase so game plugins can provide their own archive extraction and archive creation logic without expanding bsatk with game-specific formats.

What this adds:

- A reusable game feature interface for archive support
- Capability checks for:
- Whether a game supports a given archive
- Extracting an archive through the game plugin
- Creating an archive through the game plugin

Why:

- MO2 already has strong archive support for Bethesda titles through the existing built-in path
- Some games use archive formats that are not compatible with Bethesda BSAs even when they share a file extension
- This keeps format-specific logic in the game plugin instead of pushing unrelated format handling into bsatk

Intended use:

- Bethesda games can continue using the existing built-in archive flow
- Non-Bethesda games can expose GameArchiveHandler and have MO2 utilities delegate to that handler

Tested with:

- A downstream XnGine game plugin implementation
- MO2 2.5.2
- MO2 2.5.3-beta.2

Notes:

- This PR is only the interface layer
- Follow-up consumer PRs use this feature in modorganizer-bsa_extractor and bsapacker