### PR TITLE
Fix typos in interface class name and header guard

### DIFF
--- a/include/uibase/iplugingamefeatures.h
+++ b/include/uibase/iplugingamefeatures.h
@@ -38,7 +38,7 @@ class UnmanagedMods;
  * @brief A plugin to implement game features.
  *
  */
-class IPluginGameFeautres
+class IPluginGameFeatures
 {
 public:
   /**
@@ -57,5 +57,5 @@ public:
 
 }  // namespace MOBase
 
-#endif  // IPLUGINDIAGNOSE_H
+#endif  // IPLUGINGAMEFEATURES_H
 #pragma once


### PR DESCRIPTION
Fix typos in interface class name and header guard, currently no users of the interface in the ModOrganizer2 organisation that I saw.